### PR TITLE
Implement FILE endpoint in addon

### DIFF
--- a/APIClient.py
+++ b/APIClient.py
@@ -359,6 +359,12 @@ class APIClient:
 
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
 
+    @authRequired
+    def deleteFile(self, _id):
+        endpoint = f"/file/{_id}"
+
+        result = self._delete(endpoint)
+        return result
 
     #  Upload Functions
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -241,9 +241,9 @@ class APIClient:
             params = {**params, **paginationparams}
 
         result = self._request(endpoint, params=params)
-        files = result["data"]
+        models = result["data"]
 
-        return files
+        return models
 
     @authRequired
     def getModel(self, modelId):
@@ -299,6 +299,66 @@ class APIClient:
 
         result = self._delete(endpoint)
         return result
+
+    # File Objects functions
+
+    @authRequired
+    def getFiles(self, params=None):
+
+        paginationparams = {"$limit": 50, "$skip": 0, "isSystemGenerated": "false"}
+        endpoint = "file"
+        if params is None:
+            params = paginationparams
+        else:
+            params = {**params, **paginationparams}
+
+        result = self._request(endpoint, params=params)
+        files = result["data"]
+
+        return files
+
+    @authRequired
+    def createFile(self, fileName, fileUpdatedAt, uniqueName):
+        print("Creating the file object...")
+        endpoint = "file"
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "custFileName": fileName,
+            "shouldCommitNewVersion": True,
+            "version": {
+                "uniqueFileName": uniqueName,
+                "message": "",
+                "fileUpdatedAt": fileUpdatedAt
+            }
+        }
+
+        result = self._post(endpoint, headers=headers, data=json.dumps(payload))
+
+        return result
+
+    @authRequired
+    def updateFileObj(self, fileId, fileUpdatedAt, uniqueFileName):
+        print(f"Posting new version of file...")
+        endpoint = f"file/{fileId}"
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "shouldCommitNewVersion": True,
+            "version" : {
+                "uniqueFileName": uniqueFileName,
+                "fileUpdatedAt" : fileUpdatedAt,
+                "message" : ""
+            },
+        }
+
+        result = self._update(endpoint, headers=headers, data=json.dumps(payload))
+
 
     #  Upload Functions
 

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -99,19 +99,19 @@ class WorkSpaceModel(QAbstractListModel):
                 created_time = Utils.getFileCreateddAt(file_path)
                 modified_time = Utils.getFileUpdatedAt(file_path)
                 base, extension = os.path.splitext(basename)
-
-                file_item = FileItem(
-                    basename,
-                    extension.lower(),
-                    file_path,
-                    False,
-                    [basename],
-                    basename,
-                    created_time,
-                    modified_time,
-                    "Untracked",
-                )
-                local_files.append(file_item)
+                if(extension.lower() != ".fcbak"):
+                    file_item = FileItem(
+                        basename,
+                        extension.lower(),
+                        file_path,
+                        False,
+                        [basename],
+                        basename,
+                        created_time,
+                        modified_time,
+                        "Untracked",
+                    )
+                    local_files.append(file_item)
 
         return local_files
 
@@ -262,7 +262,6 @@ class ServerWorkspaceModel(WorkSpaceModel):
                         localFile.status = "Synced"
 
                     if "modelId" in serverFileDict:
-                        print(serverFileDict["modelId"])
                         localFile.serverModelDict = self.API_Client.getModel(serverFileDict["modelId"])
 
                     foundLocal = True
@@ -310,7 +309,7 @@ class ServerWorkspaceModel(WorkSpaceModel):
             return file_item.name, False
         elif role == self.IdRole:
             if file_item.serverModelDict is not None:
-                return file_item.serverModelDict["_Id"]
+                return file_item.serverModelDict["_id"]
         elif role == self.StatusRole:
             return file_item.status
         elif role == self.NameStatusAndIsFolderRole:
@@ -361,9 +360,12 @@ class ServerWorkspaceModel(WorkSpaceModel):
                 FreeCAD.loadFile(file_path)
 
     def deleteFile(self, index):
-        modelId = self.data(index, WorkSpaceModel.IdRole)
-        if modelId is not None:
-            self.API_Client.deleteModel(modelId)
+        file_item = self.files[index.row()]
+
+        if file_item.serverModelDict is not None:
+            self.API_Client.deleteModel(file_item.serverModelDict["_id"])
+        else:
+            self.API_Client.deleteFile(file_item.serverFileDict["_id"])
 
         super().deleteFile(index)
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -45,9 +45,9 @@ iconsPath = f"{modPath}/Resources/icons/"
 cachePath = f"{modPath}/Cache/"
 
 # Test server
-baseUrl = "http://ec2-54-234-132-150.compute-1.amazonaws.com"
+#baseUrl = "http://ec2-54-234-132-150.compute-1.amazonaws.com"
 # Prod server
-#baseUrl = "https://lens-api.ondsel.com/"
+baseUrl = "https://lens-api.ondsel.com/"
 lensUrl = "https://lens.ondsel.com/"
 ondselUrl = "https://www.ondsel.com/"
 


### PR DESCRIPTION
This PR implement the recent changes to the API that implement the stand-alone FILE object.
This enables the support of any file extensions.
This is draft until the changes of the API merge into PROD. @amrit3701 are those changes already in PROD?