### PR TITLE
Fix migration issue. Cf from @Amritpal :

### DIFF
--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -246,10 +246,7 @@ class ServerWorkspaceModel(WorkSpaceModel):
         serverFilesToAdd = []
         serverFiles = self.API_Client.getFiles()
         for serverFileDict in serverFiles:
-            try:
-                serverDate = serverFileDict["currentVersion"]["additionalData"]["fileUpdatedAt"]
-            except KeyError:
-                serverDate = serverFileDict["currentVersion"]["createdAt"]
+            serverDate = serverFileDict["currentVersion"]["additionalData"].get("fileUpdatedAt", serverFileDict["currentVersion"]["createdAt"])
 
             foundLocal = False
             for i, localFile in enumerate(files):

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -246,13 +246,15 @@ class ServerWorkspaceModel(WorkSpaceModel):
         serverFilesToAdd = []
         serverFiles = self.API_Client.getFiles()
         for serverFileDict in serverFiles:
+            try:
+                serverDate = serverFileDict["currentVersion"]["additionalData"]["fileUpdatedAt"]
+            except KeyError:
+                serverDate = serverFileDict["currentVersion"]["createdAt"]
+
             foundLocal = False
             for i, localFile in enumerate(files):
                 if serverFileDict["custFileName"] == localFile.name:
                     localFile.serverFileDict = serverFileDict
-                    serverDate = serverFileDict["currentVersion"]["additionalData"][
-                        "fileUpdatedAt"
-                    ]
                     localDate = localFile.updatedAt
                     # print(f"update date are : {serverDate} - {localDate}")
                     if serverDate < localDate:
@@ -287,7 +289,7 @@ class ServerWorkspaceModel(WorkSpaceModel):
                     [serverFileDict["custFileName"]],
                     serverFileDict["custFileName"],
                     serverFileDict["createdAt"],
-                    serverFileDict["currentVersion"]["additionalData"]["fileUpdatedAt"],
+                    serverDate,
                     "Server only",
                     serverFileDict,
                     serverModelDict,

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -246,7 +246,9 @@ class ServerWorkspaceModel(WorkSpaceModel):
         serverFilesToAdd = []
         serverFiles = self.API_Client.getFiles()
         for serverFileDict in serverFiles:
-            serverDate = serverFileDict["currentVersion"]["additionalData"].get("fileUpdatedAt", serverFileDict["currentVersion"]["createdAt"])
+            serverDate = serverFileDict["currentVersion"]["additionalData"].get(
+                "fileUpdatedAt", serverFileDict["currentVersion"]["createdAt"]
+            )
 
             foundLocal = False
             for i, localFile in enumerate(files):


### PR DESCRIPTION
'It looks like now addon read the old models, only thing is addon expecting fileUpdatedAt field under additionalData. @Pierre-Louis Boyer
 can you update the addon like if fileUpdatedAt not exists, the use file.versions.0.createdAt or pick from model (model.fileUpdatedAt) objects?'