### PR TITLE
Don't write data to modpath

### DIFF
--- a/DataModels.py
+++ b/DataModels.py
@@ -11,7 +11,7 @@ import json
 import shutil
 import FreeCAD
 
-modPath = os.path.dirname(__file__).replace("\\", "/")
+cachePath = FreeCAD.getUserCachePath()
 p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
 
 
@@ -31,7 +31,7 @@ class WorkspaceListModel(QAbstractListModel):
     def __init__(self, parent=None, filename=None):
         super(WorkspaceListModel, self).__init__(parent)
         self.workspaceListFile = (
-            f"{modPath}/workspaceList.json" if filename is None else filename
+            f"{cachePath}/workspaceList.json" if filename is None else filename
         )
 
         self.load()

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -43,7 +43,7 @@ mw = Gui.getMainWindow()
 p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
 modPath = os.path.dirname(__file__).replace("\\", "/")
 iconsPath = f"{modPath}/Resources/icons/"
-cachePath = f"{modPath}/Cache/"
+cachePath = FreeCAD.getUserCachePath()
 
 # Test server
 # baseUrl = "https://ec2-54-234-132-150.compute-1.amazonaws.com"


### PR DESCRIPTION
Since the first time the flavor is run it may load the addon from a non writable directory