### PR TITLE
Adapt to a new version of Lens

### DIFF
--- a/APIClient.py
+++ b/APIClient.py
@@ -401,7 +401,7 @@ class APIClient:
         directory = os.path.dirname(filename)
         os.makedirs(directory, exist_ok=True)
 
-        self._download(response["url"], filename)
+        return self._download(response["url"], filename)
 
     # Shared Model Functions
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -76,7 +76,7 @@ class APIClient:
         # dump only when debugging is enabled
         self._dump_response(response, **kwargs)
         raise APIClientException(
-            "API request failed with status code {response.status_code}"
+            f"API request failed with status code {response.status_code}"
         )
 
     def _delete(self, endpoint, headers={}, params=None):
@@ -93,8 +93,9 @@ class APIClient:
         if response.status_code == OK:
             return response.json()
         else:
-            self._raiseError(response, endpoint=endpoint,
-                             headers=headers, params=params)
+            self._raiseError(
+                response, endpoint=endpoint, headers=headers, params=params
+            )
 
     def _request(self, endpoint, headers={}, params=None):
         headers["Authorization"] = f"Bearer {self.access_token}"
@@ -109,8 +110,9 @@ class APIClient:
         if response.status_code == OK:
             return response.json()
         else:
-            self._raiseError(response, endpoint=endpoint,
-                             headers=headers, params=params)
+            self._raiseError(
+                response, endpoint=endpoint, headers=headers, params=params
+            )
 
     def _post(self, endpoint, headers={}, params=None, data=None, files=None):
         if endpoint != "authentication":
@@ -124,13 +126,18 @@ class APIClient:
         except requests.exceptions.RequestException as e:
             raise APIClientException(e)
 
+        # only _post makes a distinction between the general error and
+        # unauthorized because _authenticate makes use of post and unauthorized
+        # should be handled differently for the _authenticate function (for
+        # example give the user another try to log in).
         if response.status_code in [CREATED, OK]:
             return response.json()
         elif response.status_code == UNAUTHORIZED:
             raise APIClientAuthenticationException("Not authenticated")
         else:
-            self._raiseError(response, endpoint=endpoint, headers=headers,
-                             data=data, files=files)
+            self._raiseError(
+                response, endpoint=endpoint, headers=headers, data=data, files=files
+            )
 
     def _update(self, endpoint, headers={}, data=None, files=None):
         headers["Authorization"] = f"Bearer {self.access_token}"
@@ -146,8 +153,9 @@ class APIClient:
         if response.status_code in [CREATED, OK]:
             return response.json()
         else:
-            self._raiseError(response, endpoint=endpoint, headers=headers,
-                             data=data, files=files)
+            self._raiseError(
+                response, endpoint=endpoint, headers=headers, data=data, files=files
+            )
 
     def _download(self, url, filename):
         try:

--- a/APIClient.py
+++ b/APIClient.py
@@ -556,17 +556,18 @@ class APIClient:
         }
 
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
+        dirId = result["_id"]
 
         payload = {
             "shouldAddDirectoriesToDirectory": True,
-            "directoryIds": [result["_id"]],
+            "directoryIds": [dirId],
         }
 
         result = self._update(
             f"{endpoint}/{parentDirId}", headers=headers, data=json.dumps(payload)
         )
 
-        return result
+        return dirId
 
     @authRequired
     def updateDirectory(self, directoryData):

--- a/APIClient.py
+++ b/APIClient.py
@@ -542,7 +542,7 @@ class APIClient:
         return result
 
     @authRequired
-    def createDirectory(self, name, parentDirId, workspace):
+    def createDirectory(self, name, idParentDir, nameParentDir, workspace):
         print("Creating the directory...")
         endpoint = "directories"
 
@@ -553,21 +553,13 @@ class APIClient:
         payload = {
             "name": name,
             "workspace": workspace,
+            "parentDirectory": {
+                "_id": idParentDir,
+                "name": nameParentDir,
+            },
         }
 
-        result = self._post(endpoint, headers=headers, data=json.dumps(payload))
-        dirId = result["_id"]
-
-        payload = {
-            "shouldAddDirectoriesToDirectory": True,
-            "directoryIds": [dirId],
-        }
-
-        result = self._update(
-            f"{endpoint}/{parentDirId}", headers=headers, data=json.dumps(payload)
-        )
-
-        return dirId
+        return self._post(endpoint, headers=headers, data=json.dumps(payload))
 
     @authRequired
     def updateDirectory(self, directoryData):

--- a/APIClient.py
+++ b/APIClient.py
@@ -536,7 +536,8 @@ class APIClient:
         return result
 
     @authRequired
-    def createDirectory(self, name, parentDirId, workspaceId, workspaceName):
+    def createDirectory(self, name, parentDir, workspaceId,
+                        workspaceName, workspaceRefName):
         print("Creating the directory...")
         endpoint = "directories"
 
@@ -546,11 +547,15 @@ class APIClient:
 
         payload = {
             "name": name,
-            "parentDirectory": {
-                "_id": parentDirId,
-            },
-            "workspace": {"_id": workspaceId, "name": workspaceName},
+            "parentDirectory": parentDir,
+            "workspace": {"_id": workspaceId,
+                          "name": workspaceName,
+                          "refName": workspaceRefName},
         }
+
+        from pprint import pprint
+        pprint(headers)
+        pprint(payload)
 
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -252,7 +252,7 @@ class APIClient:
         return result
 
     @authRequired
-    def createModel(self, fileName, uniqueName, fileId):
+    def createModel(self, fileId):
         print("Creating the model...")
         endpoint = "models"
 
@@ -271,9 +271,9 @@ class APIClient:
         return result
 
     @authRequired
-    def regenerateModelObj(self, fileId, fileUpdatedAt, uniqueFileName):
+    def regenerateModelObj(self, modelId, fileUpdatedAt, uniqueFileName):
         print(f"Regenerating the model OBJ... {fileUpdatedAt}")
-        endpoint = f"models/{fileId}"
+        endpoint = f"models/{modelId}"
 
         headers = {
             "Content-Type": "application/json",
@@ -289,6 +289,8 @@ class APIClient:
         }
 
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
+
+        return result
 
     @authRequired
     def deleteModel(self, _id):

--- a/APIClient.py
+++ b/APIClient.py
@@ -1,6 +1,5 @@
 import requests
 import json
-import uuid
 import os
 
 
@@ -19,7 +18,7 @@ class APIClient:
         self.base_url = api_url
         self.lens_url = lens_url
 
-        if access_token == None:
+        if access_token is None:
             self.email = email
             self.password = password
             self.access_token = None
@@ -55,12 +54,10 @@ class APIClient:
             data = self._post(endpoint, headers=headers, data=json.dumps(payload))
             self.access_token = data["accessToken"]
             self.user = data["user"]
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             raise CustomConnectionError("Connection Error")
-
-        except CustomAuthenticationError as e:
+        except CustomAuthenticationError:
             raise CustomAuthenticationError("Authentication Error")
-
         except Exception as e:
             raise e
 
@@ -345,7 +342,7 @@ class APIClient:
     def updateFileObj(
         self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace
     ):
-        print(f"Posting new version of file...")
+        print("Posting new version of file...")
         endpoint = f"file/{fileId}"
 
         headers = {
@@ -378,7 +375,10 @@ class APIClient:
     @authRequired
     def uploadFileToServer(self, uniqueName, filename):
         print(filename)
-        # files to be uploaded needs to have a unique name generated with uuid (use str(uuid.uuid4()) ) : test.fcstd -> c4481734-c18f-4b8c-8867-9694ae2a9f5a.fcstd
+        # files to be uploaded need to have a unique name generated with uuid
+        # (use str(uuid.uuid4()) ) : test.fcstd ->
+        # c4481734-c18f-4b8c-8867-9694ae2a9f5a.fcstd
+        # Note that this is not a hash but a random identifier.
         endpoint = "upload"
 
         if not os.path.isfile(filename):

--- a/APIClient.py
+++ b/APIClient.py
@@ -252,7 +252,7 @@ class APIClient:
         return result
 
     @authRequired
-    def createModel(self, fileName, fileUpdatedAt, uniqueName):
+    def createModel(self, fileName, uniqueName, fileId):
         print("Creating the model...")
         endpoint = "models"
 
@@ -263,9 +263,9 @@ class APIClient:
         payload = {
             "custFileName": fileName,
             "uniqueFileName": uniqueName,
+            "fileId": fileId,
             "shouldStartObjGeneration": True,
             "errorMsg": "",
-            "fileUpdatedAt": fileUpdatedAt,
         }
 
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
@@ -316,7 +316,7 @@ class APIClient:
         return files
 
     @authRequired
-    def createFile(self, fileName, fileUpdatedAt, uniqueName):
+    def createFile(self, fileName, fileUpdatedAt, uniqueName, directory, workspace):
         print("Creating the file object...")
         endpoint = "file"
 
@@ -332,6 +332,8 @@ class APIClient:
                 "message": "",
                 "fileUpdatedAt": fileUpdatedAt,
             },
+            "directory": directory,
+            "workspace": workspace,
         }
 
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
@@ -339,7 +341,7 @@ class APIClient:
         return result
 
     @authRequired
-    def updateFileObj(self, fileId, fileUpdatedAt, uniqueFileName):
+    def updateFileObj(self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace):
         print(f"Posting new version of file...")
         endpoint = f"file/{fileId}"
 
@@ -353,9 +355,13 @@ class APIClient:
                 "fileUpdatedAt": fileUpdatedAt,
                 "message": "",
             },
+            "directory": directory,
+            "workspace": workspace,
         }
 
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
+
+        return result
 
     @authRequired
     def deleteFile(self, _id):
@@ -536,8 +542,7 @@ class APIClient:
         return result
 
     @authRequired
-    def createDirectory(self, name, parentDir, workspaceId,
-                        workspaceName, workspaceRefName):
+    def createDirectory(self, name, parentDirId, workspace):
         print("Creating the directory...")
         endpoint = "directories"
 
@@ -547,17 +552,18 @@ class APIClient:
 
         payload = {
             "name": name,
-            "parentDirectory": parentDir,
-            "workspace": {"_id": workspaceId,
-                          "name": workspaceName,
-                          "refName": workspaceRefName},
+            "workspace": workspace,
         }
 
-        from pprint import pprint
-        pprint(headers)
-        pprint(payload)
-
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
+
+        payload = {
+            "shouldAddDirectoriesToDirectory": True,
+            "directoryIds": [result["_id"]],
+        }
+
+        result = self._update(f"{endpoint}/{parentDirId}",
+                              headers=headers, data=json.dumps(payload))
 
         return result
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -2,6 +2,10 @@ import requests
 import json
 import os
 
+import Utils
+
+logger = Utils.getLogger(__name__)
+
 
 class CustomAuthenticationError(Exception):
     pass
@@ -116,6 +120,7 @@ class APIClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         headers["Accept"] = "application/json"
         try:
+            logger.debug(f"Posting {endpoint} {data} {files}")
             response = requests.post(
                 f"{self.base_url}/{endpoint}", headers=headers, data=data, files=files
             )
@@ -315,7 +320,7 @@ class APIClient:
 
     @authRequired
     def createFile(self, fileName, fileUpdatedAt, uniqueName, directory, workspace):
-        print("Creating the file object...")
+        logger.debug(f"Creating file {fileName} in dir {directory}")
         endpoint = "file"
 
         headers = {
@@ -342,7 +347,7 @@ class APIClient:
     def updateFileObj(
         self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace
     ):
-        print("Posting new version of file...")
+        logger.debug(f"updatingFileObj {fileId} in dir {directory}")
         endpoint = f"file/{fileId}"
 
         headers = {

--- a/APIClient.py
+++ b/APIClient.py
@@ -235,7 +235,7 @@ class APIClient:
 
     @authRequired
     def createModel(self, fileId):
-        print("Creating the model...")
+        logger.debug("Creating the model...")
         endpoint = "models"
 
         headers = {
@@ -254,7 +254,7 @@ class APIClient:
 
     @authRequired
     def regenerateModelObj(self, modelId, fileId):
-        print("Regenerating the model OBJ... ")
+        logger.debug("Regenerating the model OBJ... ")
         endpoint = f"models/{modelId}"
 
         headers = {
@@ -484,7 +484,7 @@ class APIClient:
 
     @authRequired
     def createWorkspace(self, name, description, organizationId):
-        print("Creating the workspace...")
+        logger.debug("Creating the workspace...")
         endpoint = "workspaces"
 
         headers = {
@@ -543,7 +543,7 @@ class APIClient:
 
     @authRequired
     def createDirectory(self, name, idParentDir, nameParentDir, workspace):
-        print("Creating the directory...")
+        logger.debug("Creating the directory...")
         endpoint = "directories"
 
         headers = {

--- a/APIClient.py
+++ b/APIClient.py
@@ -120,7 +120,6 @@ class APIClient:
             headers["Authorization"] = f"Bearer {self.access_token}"
         headers["Accept"] = "application/json"
         try:
-            logger.debug(f"Posting {endpoint} {data} {files}")
             response = requests.post(
                 f"{self.base_url}/{endpoint}", headers=headers, data=data, files=files
             )

--- a/APIClient.py
+++ b/APIClient.py
@@ -261,11 +261,9 @@ class APIClient:
         }
 
         payload = {
-            "custFileName": fileName,
-            "uniqueFileName": uniqueName,
             "fileId": fileId,
-            "shouldStartObjGeneration": True,
-            "errorMsg": "",
+            "shouldStartObjGeneration": False,
+            "createSystemGeneratedShareLink": False,
         }
 
         result = self._post(endpoint, headers=headers, data=json.dumps(payload))
@@ -329,7 +327,7 @@ class APIClient:
             "shouldCommitNewVersion": True,
             "version": {
                 "uniqueFileName": uniqueName,
-                "message": "",
+                "message": "Initial commit",
                 "fileUpdatedAt": fileUpdatedAt,
             },
             "directory": directory,

--- a/APIClient.py
+++ b/APIClient.py
@@ -281,10 +281,13 @@ class APIClient:
         payload = {
             # "shouldCommitNewVersion": True,
             "fileId": fileId,
-            "shouldStartObjGeneration": False,
+            "shouldStartObjGeneration": True,
             # "createSystemGeneratedShareLink": False,
         }
 
+        from pprint import pprint
+        pprint(payload)
+        print(modelId)
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
 
         return result

--- a/APIClient.py
+++ b/APIClient.py
@@ -363,8 +363,8 @@ class APIClient:
         return result
 
     @authRequired
-    def deleteFile(self, _id):
-        endpoint = f"/file/{_id}"
+    def deleteFile(self, fileId):
+        endpoint = f"file/{fileId}"
 
         result = self._delete(endpoint)
         return result

--- a/APIClient.py
+++ b/APIClient.py
@@ -286,6 +286,7 @@ class APIClient:
         }
 
         from pprint import pprint
+
         pprint(payload)
         print(modelId)
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))

--- a/APIClient.py
+++ b/APIClient.py
@@ -271,21 +271,18 @@ class APIClient:
         return result
 
     @authRequired
-    def regenerateModelObj(self, modelId, fileUpdatedAt, uniqueFileName):
-        print(f"Regenerating the model OBJ... {fileUpdatedAt}")
+    def regenerateModelObj(self, modelId, fileId):
+        print("Regenerating the model OBJ... ")
         endpoint = f"models/{modelId}"
 
         headers = {
             "Content-Type": "application/json",
         }
         payload = {
-            "shouldCommitNewVersion": True,
-            "version": {
-                "uniqueFileName": uniqueFileName,
-                "fileUpdatedAt": fileUpdatedAt,
-                "message": "Commit message",
-            },
-            "shouldStartObjGeneration": True,
+            # "shouldCommitNewVersion": True,
+            "fileId": fileId,
+            "shouldStartObjGeneration": False,
+            # "createSystemGeneratedShareLink": False,
         }
 
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
@@ -355,7 +352,7 @@ class APIClient:
             "version": {
                 "uniqueFileName": uniqueFileName,
                 "fileUpdatedAt": fileUpdatedAt,
-                "message": "",
+                "message": "Update from the Ondsel Lens addon",
             },
             "directory": directory,
             "workspace": workspace,

--- a/APIClient.py
+++ b/APIClient.py
@@ -244,7 +244,7 @@ class APIClient:
 
         payload = {
             "fileId": fileId,
-            "shouldStartObjGeneration": False,
+            "shouldStartObjGeneration": True,
             "createSystemGeneratedShareLink": False,
         }
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -308,6 +308,7 @@ class APIClient:
             "shouldCommitNewVersion": True,
             "version": {
                 "uniqueFileName": uniqueName,
+                # "message": "Initial commit from the Ondsel Lens addon",
                 "message": "Initial commit",
                 "fileUpdatedAt": fileUpdatedAt,
             },
@@ -321,7 +322,7 @@ class APIClient:
 
     @authRequired
     def updateFileObj(
-        self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace
+        self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace, message
     ):
         logger.debug(f"updatingFileObj {fileId} in dir {directory}")
         endpoint = f"file/{fileId}"
@@ -334,7 +335,7 @@ class APIClient:
             "version": {
                 "uniqueFileName": uniqueFileName,
                 "fileUpdatedAt": fileUpdatedAt,
-                "message": "Update from the Ondsel Lens addon",
+                "message": message,
             },
             "directory": directory,
             "workspace": workspace,

--- a/APIClient.py
+++ b/APIClient.py
@@ -76,7 +76,8 @@ class APIClient:
         # dump only when debugging is enabled
         self._dump_response(response, **kwargs)
         raise APIClientException(
-            f"API request failed with status code {response.status_code}"
+            f"API request failed with status code {response.status_code}: "
+            + response.json()["message"]
         )
 
     def _delete(self, endpoint, headers={}, params=None):
@@ -188,7 +189,7 @@ class APIClient:
         # Access response body as text
         logger.debug(f"Response body (text): {response.text}")
 
-        if response.headers["Content-Type"] == "application/json":
+        if response.headers["Content-Type"].startswith("application/json"):
             # Access response body as JSON
             logger.debug(f"Response body (JSON): {response.json()}")
 
@@ -341,6 +342,23 @@ class APIClient:
             },
             "directory": directory,
             "workspace": workspace,
+        }
+
+        result = self._update(endpoint, headers=headers, data=json.dumps(payload))
+
+        return result
+
+    @authRequired
+    def setVersionActive(self, fileId, versionId):
+        logger.debug("setVersionActive")
+        endpoint = f"file/{fileId}"
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "shouldCheckoutToVersion": True,
+            "versionId": versionId,
         }
 
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))

--- a/APIClient.py
+++ b/APIClient.py
@@ -341,7 +341,9 @@ class APIClient:
         return result
 
     @authRequired
-    def updateFileObj(self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace):
+    def updateFileObj(
+        self, fileId, fileUpdatedAt, uniqueFileName, directory, workspace
+    ):
         print(f"Posting new version of file...")
         endpoint = f"file/{fileId}"
 
@@ -562,8 +564,9 @@ class APIClient:
             "directoryIds": [result["_id"]],
         }
 
-        result = self._update(f"{endpoint}/{parentDirId}",
-                              headers=headers, data=json.dumps(payload))
+        result = self._update(
+            f"{endpoint}/{parentDirId}", headers=headers, data=json.dumps(payload)
+        )
 
         return result
 

--- a/APIClient.py
+++ b/APIClient.py
@@ -267,10 +267,6 @@ class APIClient:
             # "createSystemGeneratedShareLink": False,
         }
 
-        from pprint import pprint
-
-        pprint(payload)
-        print(modelId)
         result = self._update(endpoint, headers=headers, data=json.dumps(payload))
 
         return result
@@ -400,12 +396,10 @@ class APIClient:
     @authRequired
     def downloadFileFromServer(self, uniqueName, filename):
         endpoint = f"/upload/{uniqueName}"
-        print(filename)
 
         response = self._request(endpoint)
         directory = os.path.dirname(filename)
         os.makedirs(directory, exist_ok=True)
-        print(response)
 
         self._download(response["url"], filename)
 

--- a/DataModels.py
+++ b/DataModels.py
@@ -11,7 +11,7 @@ import json
 import shutil
 import FreeCAD
 
-cachePath = FreeCAD.getUserCachePath()
+CACHE_PATH = FreeCAD.getUserCachePath()
 p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
 
 
@@ -32,30 +32,31 @@ class WorkspaceListModel(QAbstractListModel):
         parent = kwargs.get("parent", None)
         super(WorkspaceListModel, self).__init__(parent)
 
-        self.WorkspaceView = kwargs["WorkspaceView"]
+        self.workspaceView = kwargs["WorkspaceView"]
 
-        self.workspaceListFile = f"{cachePath}/workspaceList.json"
+        self.workspaceListFile = f"{CACHE_PATH}/workspaceList.json"
 
         self.refreshModel()
 
     def refreshModel(self):
         self.beginResetModel()
-        if self.WorkspaceView.apiClient is not None:
-            self.workspaces = self.WorkspaceView.apiClient.getWorkspaces()
+        if self.workspaceView.isLoggedIn():
+            self.workspaces = self.workspaceView.apiClient.getWorkspaces()
 
             # Add keys that we need locally
-            for workspace in self.workspaces:
-                workspace["path"] = cachePath + workspace["_id"]
+            # Is this still necessary?!?!
+            # for workspace in self.workspaces:
+            #     workspace["path"] = CACHE_PATH + workspace["_id"]
 
-                organizationName = next(
-                    (
-                        org["name"]
-                        for org in self.WorkspaceView.user["organizations"]
-                        if org["_id"] == workspace["organizationId"]
-                    ),
-                    "",
-                )
-                workspace["organizationName"] = organizationName
+            #     organizationName = next(
+            #         (
+            #             org["name"]
+            #             for org in self.workspaceView.user["organizations"]
+            #             if org["_id"] == workspace["organizationId"]
+            #         ),
+            #         "",
+            #     )
+            #     workspace["organizationName"] = organizationName
             self.save()
         else:
             self.load()

--- a/DataModels.py
+++ b/DataModels.py
@@ -4,14 +4,14 @@
 # *                                                                     *
 # ***********************************************************************
 
-from PySide.QtCore import Qt, QAbstractTableModel, QAbstractListModel, QModelIndex
-from PySide import QtCore
+
+from PySide.QtCore import Qt, QAbstractListModel, QModelIndex
 import os
 import json
-import shutil
 import FreeCAD
+from pathlib import Path
 
-CACHE_PATH = FreeCAD.getUserCachePath()
+CACHE_PATH = FreeCAD.getUserCachePath() + "Ondsel-Lens/"
 p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
 
 
@@ -77,7 +77,8 @@ class WorkspaceListModel(QAbstractListModel):
         self.endResetModel()
         self.save()
 
-    """def addWorkspace(self, workspaceName, workspaceDesc, workspaceType, workspaceUrl, _id, organisation, rootDirectory):
+    """def addWorkspace(self, workspaceName, workspaceDesc, workspaceType, workspaceUrl,
+                     _id, organisation, rootDirectory):
         for workspace in reversed(self.workspaces):
             if workspace["name"] == workspaceName:
                 if workspaceType == "Ondsel" and workspace["type"] == "Local":
@@ -137,6 +138,8 @@ class WorkspaceListModel(QAbstractListModel):
                 self.workspaces = json.loads(dataStr)
 
     def save(self):
+        dirname = os.path.dirname(self.workspaceListFile)
+        Path(dirname).mkdir(parents=True, exist_ok=True)
         with open(self.workspaceListFile, "w") as file:
             file.write(json.dumps(self.workspaces))
 
@@ -156,7 +159,8 @@ class WorkspaceListModel(QAbstractListModel):
 
 # Unused
 class FilesData:
-    """This class contains all the data of the workspaces and their files under the structure of a dictionary :
+    """This class contains all the data of the workspaces and their files under the
+    structure of a dictionary :
     [
         {
             "Name" : "myWorkspace",

--- a/DataModels.py
+++ b/DataModels.py
@@ -64,56 +64,42 @@ class WorkspaceListModel(QAbstractListModel):
         self.endResetModel()
         self.save()
 
-    """def addWorkspace(self, workspaceName, workspaceDesc, workspaceType, workspaceUrl,
-                     _id, organisation, rootDirectory):
-        for workspace in reversed(self.workspaces):
-            if workspace["name"] == workspaceName:
-                if workspaceType == "Ondsel" and workspace["type"] == "Local":
-                    workspace["type"] = "Ondsel"
-                    self.save()
-                return
+    # def addWorkspace(self, workspaceName, workspaceDesc, workspaceType, workspaceUrl,
+    #                  _id, organisation, rootDirectory):
+    #     for workspace in reversed(self.workspaces):
+    #         if workspace["name"] == workspaceName:
+    #             if workspaceType == "Ondsel" and workspace["type"] == "Local":
+    #                 workspace["type"] = "Ondsel"
+    #                 self.save()
+    #             return
 
-        self.beginInsertRows(QtCore.QModelIndex(), self.rowCount(), self.rowCount())
-        self.workspaces.append(
-            {
-                "name": workspaceName,
-                "description": workspaceDesc,
-                "type": workspaceType,
-                "url": workspaceUrl,
-                "_id": _id,
-                "organizationId": organisation,
-                "rootDirectory" : rootDirectory,
-                "currentDirectory" : rootDirectory
-            }
-        )
-        self.endInsertRows()
-        self.save()
+    #     self.beginInsertRows(QtCore.QModelIndex(), self.rowCount(), self.rowCount())
+    #     self.workspaces.append(
+    #         {
+    #             "name": workspaceName,
+    #             "description": workspaceDesc,
+    #             "type": workspaceType,
+    #             "url": workspaceUrl,
+    #             "_id": _id,
+    #             "organizationId": organisation,
+    #             "rootDirectory" : rootDirectory,
+    #             "currentDirectory" : rootDirectory
+    #         }
+    #     )
+    #     self.endInsertRows()
+    #     self.save()
 
-    def removeWorkspace(self, index):
-        if index.isValid() and 0 <= index.row() < len(self.workspaces):
-            self.beginRemoveRows(QtCore.QModelIndex(), index.row(), index.row())
-            del self.workspaces[index.row()]
-            self.endRemoveRows()
-            self.save()
+    # def removeWorkspace(self, index):
+    #     if index.isValid() and 0 <= index.row() < len(self.workspaces):
+    #         self.beginRemoveRows(QtCore.QModelIndex(), index.row(), index.row())
+    #         del self.workspaces[index.row()]
+    #         self.endRemoveRows()
+    #         self.save()
 
-    def removeOndselWorkspaces(self):
+    def removeWorkspaces(self):
         self.beginResetModel()
-
-        for workspace in reversed(self.workspaces):
-            if workspace["type"] == "Ondsel":
-                if p.GetBool("clearCache", False):
-                    # Delete the Ondsel local Folder
-                    try:
-                        shutil.rmtree(workspace["url"])
-                    except FileNotFoundError:
-                        print("Directory does not exist")
-
-                    self.workspaces.remove(workspace)
-                else:
-                    workspace["type"] = "Local"
-
+        self.workspaces = []
         self.endResetModel()
-        self.save()"""
 
     def load(self):
         self.workspaces = []

--- a/DataModels.py
+++ b/DataModels.py
@@ -39,24 +39,11 @@ class WorkspaceListModel(QAbstractListModel):
         self.refreshModel()
 
     def refreshModel(self):
+        # raises an APIClientException
         self.beginResetModel()
         if self.workspaceView.isLoggedIn():
             self.workspaces = self.workspaceView.apiClient.getWorkspaces()
 
-            # Add keys that we need locally
-            # Is this still necessary?!?!
-            # for workspace in self.workspaces:
-            #     workspace["path"] = CACHE_PATH + workspace["_id"]
-
-            #     organizationName = next(
-            #         (
-            #             org["name"]
-            #             for org in self.workspaceView.user["organizations"]
-            #             if org["_id"] == workspace["organizationId"]
-            #         ),
-            #         "",
-            #     )
-            #     workspace["organizationName"] = organizationName
             self.save()
         else:
             self.load()

--- a/DataModels.py
+++ b/DataModels.py
@@ -41,7 +41,6 @@ class WorkspaceListModel(QAbstractListModel):
     def refreshModel(self):
         self.beginResetModel()
         if self.WorkspaceView.apiClient is not None:
-
             self.workspaces = self.WorkspaceView.apiClient.getWorkspaces()
 
             # Add keys that we need locally

--- a/DataModels.py
+++ b/DataModels.py
@@ -39,7 +39,9 @@ class WorkspaceListModel(QAbstractListModel):
         self.refreshModel()
 
     def refreshModel(self):
+        self.beginResetModel()
         if self.WorkspaceView.apiClient is not None:
+
             self.workspaces = self.WorkspaceView.apiClient.getWorkspaces()
 
             # Add keys that we need locally
@@ -58,6 +60,7 @@ class WorkspaceListModel(QAbstractListModel):
             self.save()
         else:
             self.load()
+        self.endResetModel()
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.workspaces)

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Ondsel Lens Addon
 
-This FreeCAD addon provides an easy way to upload designs
+This FreeCAD addon provides a convenient way to upload designs
 to [Lens](https://lens.ondsel.com), a cloud service by Ondsel, designed
-to publicly share and manipulate FreeCAD projects. The addon is
-currently in private beta and requires manual installation.
+to publicly share and manipulate FreeCAD projects. 
 
 ## Installation
 
-The Ondsel Lens addon is now available through the FreeCAD Addon Manager. 
+The Ondsel Lens addon is already installed by default in [Ondsel ES](https://ondsel.com/download/).
+For FreeCAD, the Ondsel Lens addon is available through the FreeCAD Addon Manager. 
 
 Open the Addon manager. Find in the list 'Ondsel-Lens' and install it.
 The installation will require restarting FreeCAD.
 
-You should see the Ondsel Addon shown on the right side of FreeCAD. If it doesn't appear, right-click on the toolbar area and toggle the visibility of the 'Workspace View'.
+You should see the Ondsel Addon shown on the right side of FreeCAD. If it doesn't appear, right-click on the toolbar area and toggle the visibility of the 'Ondsel Lens'.
 
 ![image](https://github.com/Ondsel-Development/Ondsel-Lens/assets/538057/4ecccf11-6797-4c81-815e-1fc66db87b08)
 
 ## Dependencies
 
-The addon requires a couple of additional Python dependencies that should be installed automatically by the FreeCAD addon manager, these will be installed automatically.  For now, you may need to install them manually.
+The addon requires a couple of additional Python dependencies that should be installed automatically by the FreeCAD addon manager.
 
-If you have a problem you can install them manually by :
+If you have a problem with dependencies you can install them manually by:
 Open the Python console in FreeCAD and enter the following code
 
 ```
@@ -33,29 +33,36 @@ Note: ```pip install jwt``` installs the wrong library. You need ```pip install 
 
 ## First Use (What does the addon do?)
 
-The addon introduces the notion of 'workspaces'. Workspaces are collections
-of files that constitute a project. Workspaces are either local or hosted on
-the Ondsel Lens server.
+The addon introduces the notion of "workspaces". Workspaces are collections of
+files that constitute a project and are hosted on the Ondsel Lens server.  To
+start working and collaborating on FreeCAD designs, you must create an account
+on Ondsel by following the signup link in the dropdown menu.
 
-### Local workspaces
+Once an account is created, you can log in through the addon and enter your
+workspace "Default (Personal)".  From here you can save files and access them
+from another location.
 
-You may create as many local workspaces as you like.  Each workspace simply
-maps to a folder on your hard drive. The workspace will only show the contents
-of the folder which are openable by FreeCAD.  Selecting a FreeCAD file will
-show additional details including any backup versions in the folder. You can
-revert to an earlier version from here if needed.
-
-![image](https://github.com/Ondsel-Development/Ondsel-Lens/assets/538057/57c8942f-6387-4fa2-9ead-4403306b8c6f)
-
-### Ondsel Workspace
-
-An Ondsel workspace works much like a local workspace. To create one, you must
-create an account on Ondsel by following the signup link in the dropdown menu.
-
-Once an account is created, you can log in through the addon and enter the
-workspace. From here you can save files and access them from another location.
-
+<!-- needs to be updated with images from the new flavor -->
 ![image](https://github.com/Ondsel-Development/Ondsel-Lens/assets/538057/07d8b957-efe8-4140-a9a5-2a6a3140d507)
+
+### Workspaces
+
+A workspace maps to a folder on your hard drive and contains files
+and folders.  Files can be in five different states:
+
+- "Untracked": Ondsel Lens does not track this file
+- "Not downloaded": The file is only available on Lens
+- "Synced": the local version is in sync with the Ondsel Lens version
+- "Local copy newer": The local version is newer than the server one
+- "Lens copy newer": The server version is newer than the local one
+
+By means of download and upload actions, files can be synchronized with the
+Lens service and Lens maintains different versions for files.  One version of
+each file is marked as the active version which typically is the last
+version of a file.  Uploading a new version makes that version the active one.
+
+The addon shows additional details for FreeCAD files.  It shows a thumbnail
+of the file, the version information and share links of the file.
 
 ### Sharing Links
 
@@ -64,16 +71,18 @@ the website. [Sharing links](https://lens.ondsel.com/share/6488bfa93649fe410974f
 can also be fine-tuned to permit the recipient certain privileges including
 download formats.
 
-## The state of the Beta
+### Offline workflow
 
-This is an _early_ beta.  We know there are many bugs and missing features. Expect the UI to change significantly.  This will require you to pull the latest code from the GitHub repository.  
+The addon also allows for an offline workflow.  If a user is logged out, it is
+still possible to work on the files of workspaces that are currently on disk.
+As soon as a user logs into Lens, the user has the ability to upload the new
+versions to Lens.
 
-During this beta, backward compatibility may not be supported between versions for the models you upload on the server. If you encounter errors messages such as 'fileUpdatedAt key does not exist' it is a backward compatibility issue and you will have to delete your old models from the server and upload them again.
+## Contact
 
-We are grateful to you for trying the addon and letting us know what you think.
+We are grateful to you for using the addon and letting us know what you think.
 The best place to talk with us about bugs and features is on our [Discord Server](https://discord.gg/7jmzezyyfP)
 
-We've also started a [discussion on GithHub](https://github.com/Ondsel-Development/Ondsel-Lens/discussions/25)
-to collect feedback from early adopters.
-
-We have many improvements and additional features planned. We're excited you're here with us!
+We have many improvements and additional features planned.  Follow the development on the
+[GitHub page](https://github.com/Ondsel-Development/Ondsel-Lens) and feel free to raise issues there.
+We're excited you're here with us!

--- a/SharingLinkEditDialog.ui
+++ b/SharingLinkEditDialog.ui
@@ -27,16 +27,30 @@
       <widget class="QLineEdit" name="linkName"/>
      </item>
      <item>
-      <widget class="QCheckBox" name="canViewModelAttributesCheckBox">
+      <widget class="QCheckBox" name="canViewModelCheckBox">
        <property name="text">
-        <string>Show model attributes</string>
+        <string>Can view model</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="canUpdateModelCheckBox">
+      <widget class="QCheckBox" name="canViewModelAttributesCheckBox">
        <property name="text">
-        <string>Allow updating the model</string>
+        <string>Can view model attributes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="canUpdateModelAttributesCheckBox">
+       <property name="text">
+        <string>Can update model attributes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="canDownloadOriginalCheckBox">
+       <property name="text">
+        <string>Can download original model</string>
        </property>
       </widget>
      </item>

--- a/SharingLinkEditDialog.ui
+++ b/SharingLinkEditDialog.ui
@@ -100,9 +100,9 @@
    <item>
     <layout class="QHBoxLayout">
      <item>
-      <widget class="QPushButton" name="cancelBtn">
+      <widget class="QPushButton" name="okBtn">
        <property name="text">
-        <string>Cancel</string>
+        <string>Ok</string>
        </property>
       </widget>
      </item>
@@ -126,9 +126,9 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="okBtn">
+      <widget class="QPushButton" name="cancelBtn">
        <property name="text">
-        <string>Ok</string>
+        <string>Cancel</string>
        </property>
       </widget>
      </item>

--- a/Utils.py
+++ b/Utils.py
@@ -13,7 +13,7 @@ from PySide2.QtGui import QPixmap
 
 modPath = os.path.dirname(__file__).replace("\\", "/")
 
-DEBUG_LEVEL = logging.DEBUG
+DEBUG_LEVEL = logging.INFO
 
 
 class FreeCADHandler(logging.Handler):
@@ -98,7 +98,10 @@ def getLogger(name):
     logger = logging.getLogger(name)
     logger.setLevel(DEBUG_LEVEL)
     handler = FreeCADHandler()
-    formatter = logging.Formatter("%(levelname)s: %(name)s:%(lineno)d %(message)s")
+    if DEBUG_LEVEL >= logging.INFO:
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+    else:
+        formatter = logging.Formatter("%(levelname)s: %(name)s:%(lineno)d %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger

--- a/Utils.py
+++ b/Utils.py
@@ -98,7 +98,7 @@ def getLogger(name):
     logger = logging.getLogger(name)
     logger.setLevel(DEBUG_LEVEL)
     handler = FreeCADHandler()
-    formatter = logging.Formatter('%(levelname)s: %(name)s:%(lineno)d %(message)s')
+    formatter = logging.Formatter("%(levelname)s: %(name)s:%(lineno)d %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger

--- a/Utils.py
+++ b/Utils.py
@@ -75,11 +75,23 @@ def extract_thumbnail(file_path):
 
 
 def getFileUpdatedAt(file_path):
+    "Returns the modified time in milliseconds"
     return math.floor(os.path.getmtime(file_path) * 1000)
 
 
-def getFileCreateddAt(file_path):
+def getFileCreatedAt(file_path):
+    "Returns the created time in milliseconds"
     return math.floor(os.path.getctime(file_path) * 1000)
+
+
+def setFileModificationTimes(file_path, updatedAt, createdAt):
+    """
+    Set the modified and created time for a file
+
+    The parameters createdAt and updatedAt are in milliseconds,
+    whereas os.utime expects a float in seconds
+    """
+    os.utime(file_path, (createdAt / 1000.0, updatedAt / 1000.0))
 
 
 def getLogger(name):

--- a/Utils.py
+++ b/Utils.py
@@ -13,7 +13,7 @@ from PySide2.QtGui import QPixmap
 
 modPath = os.path.dirname(__file__).replace("\\", "/")
 
-DEBUG_LEVEL = logging.DEBUG
+DEBUG_LEVEL = logging.INFO
 
 
 class FreeCADHandler(logging.Handler):

--- a/Utils.py
+++ b/Utils.py
@@ -13,7 +13,7 @@ from PySide2.QtGui import QPixmap
 
 modPath = os.path.dirname(__file__).replace("\\", "/")
 
-DEBUG_LEVEL = logging.INFO
+DEBUG_LEVEL = logging.DEBUG
 
 
 class FreeCADHandler(logging.Handler):

--- a/Utils.py
+++ b/Utils.py
@@ -8,9 +8,27 @@ import os
 import FreeCAD
 import zipfile
 import math
+import logging
 from PySide2.QtGui import QPixmap
 
 modPath = os.path.dirname(__file__).replace("\\", "/")
+
+DEBUG_LEVEL = logging.DEBUG
+
+
+class FreeCADHandler(logging.Handler):
+    def __init__(self):
+        logging.Handler.__init__(self)
+
+    def emit(self, record):
+        msg = self.format(record) + "\n"
+        c = FreeCAD.Console
+        if record.levelno >= logging.ERROR:
+            c.PrintError(msg)
+        elif record.levelno >= logging.WARNING:
+            c.PrintWarning(msg)
+        else:
+            c.PrintMessage(msg)
 
 
 def joinPath(first, second):
@@ -51,7 +69,8 @@ def extract_thumbnail(file_path):
             # Handle the case where the thumbnail file doesn't exist
             return None
     else:
-        # If file doesn't exist then the file is on the server only. We could fetch the server thumbnail.
+        # If file doesn't exist then the file is on the server only. We could fetch the
+        # server thumbnail.
         return None
 
 
@@ -61,3 +80,13 @@ def getFileUpdatedAt(file_path):
 
 def getFileCreateddAt(file_path):
     return math.floor(os.path.getctime(file_path) * 1000)
+
+
+def getLogger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(DEBUG_LEVEL)
+    handler = FreeCADHandler()
+    formatter = logging.Formatter('%(levelname)s: %(name)s:%(lineno)d %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger

--- a/VersionModel.py
+++ b/VersionModel.py
@@ -261,6 +261,9 @@ class OndselVersionModel(VersionModel):
 
         self.beginResetModel()
         self.versions = fileDict["versions"][::-1]
+        self.namesUsers = {
+            user["_id"]: user["name"] for user in fileDict["relatedUserDetails"]
+        }
 
         # The version that is active on the server
         self.currentVersionId = fileDict["currentVersionId"]
@@ -307,9 +310,15 @@ class OndselVersionModel(VersionModel):
             return (self.convertTime(version["createdAt"] // 1000)) + (
                 " ✔️" if version["_id"] == self.currentVersionId else ""
             )
-
-        # Additional role for accessing the unique filename and the version Id
-        if role == Qt.UserRole:
+        elif role == Qt.ToolTipRole:
+            nameUser = self.namesUsers.get(version["userId"])
+            if nameUser:
+                nameUser = f" - {nameUser}"
+            else:
+                nameUser = ""
+            return f"{version['message']}{nameUser}"
+        elif role == Qt.UserRole:
+            # Additional role for accessing the unique filename and the version Id
             return version
 
         return None

--- a/VersionModel.py
+++ b/VersionModel.py
@@ -16,6 +16,9 @@ import Utils
 logger = Utils.getLogger(__name__)
 
 
+CONVERT_TO_LOCAL_TZ = True
+
+
 class VersionModel(QAbstractListModel):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -45,7 +48,7 @@ class VersionModel(QAbstractListModel):
     def data(self, index, role):
         pass  # Implemented in subclasses
 
-    def convertTime(self, time):
+    def convertTime(self, time, convertToLocalTZ=False):
         """
         This converts a time string to the user's local timezone using tzlocal
         and outputs it in a friendly format
@@ -60,15 +63,16 @@ class VersionModel(QAbstractListModel):
             else:
                 time_obj = datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
 
-            # Convert the time to the user's local timezone
-            local_time_obj = time_obj.replace(tzinfo=datetime.timezone.utc).astimezone(
-                user_timezone
-            )
+            if convertToLocalTZ:
+                # Convert the time to the user's local timezone
+                time_obj = time_obj.replace(tzinfo=datetime.timezone.utc).astimezone(
+                    user_timezone
+                )
 
             # Format the local time as a friendly string
-            local_time_str = local_time_obj.strftime("%Y-%m-%d %H:%M:%S")
+            time_str = time_obj.strftime("%Y-%m-%d %H:%M:%S")
 
-            return local_time_str
+            return time_str
         except ValueError:
             # Handle invalid time string format
             return "Invalid time format"
@@ -146,7 +150,9 @@ class LocalVersionModel(VersionModel):
                 program_version = root.get("ProgramVersion")
 
                 # Add the values to the result dictionary
-                result["CreationDate"] = self.convertTime(lastModifiedDate)
+                result["CreationDate"] = self.convertTime(
+                    lastModifiedDate, CONVERT_TO_LOCAL_TZ
+                )
                 result["ProgramVersion"] = program_version
 
         return result

--- a/VersionModel.py
+++ b/VersionModel.py
@@ -30,8 +30,6 @@ class VersionModel(QAbstractListModel):
         used.
         """
         createdDate = version["createdAt"]
-        hasFileUpdatedAt = "fileUpdatedAt" in version["additionalData"]
-        logger.debug(f"has fileUpdatedAt? {hasFileUpdatedAt}")
         updatedDate = version["additionalData"].get("fileUpdatedAt", createdDate)
         return updatedDate, createdDate
 
@@ -271,6 +269,13 @@ class OndselVersionModel(VersionModel):
 
         self.onDiskVersionId = self.getOnDiskVersionId(fileItem)
         self.endResetModel()
+
+    def canBeMadeActive(self):
+        """Whether the version on disk can be made active"""
+        return (
+            self.onDiskVersionId is not None
+            and self.onDiskVersionId != self.currentVersionId
+        )
 
     def getCurrentVersionId(self):
         """Get the current version.

--- a/VersionModel.py
+++ b/VersionModel.py
@@ -245,8 +245,6 @@ class OndselVersionModel(VersionModel):
         version on the server we return the versionId, otherwise None.
         """
         path = fileItem.getPath()
-        logger.debug(f"path: {path}")
-        logger.debug(f"fileItem: {fileItem}")
         if os.path.isfile(path):
             updatedAtDisk = Utils.getFileUpdatedAt(path)
             for version in self.versions:

--- a/VersionModel.py
+++ b/VersionModel.py
@@ -196,16 +196,17 @@ class LocalVersionModel(VersionModel):
 
 
 class OndselVersionModel(VersionModel):
-    def __init__(self, model_id, API_Client, parent=None):
+    def __init__(self, model_id, apiClient, parent=None):
         super().__init__(parent)
         self.model_id = model_id
-        self.API_Client = API_Client
+        self.apiClient = apiClient
 
         self.refreshModel()
 
     def refreshModel(self):
+        # raises an APIClientException
         self.clearModel()
-        model = self.API_Client.getModel(self.model_id)
+        model = self.apiClient.getModel(self.model_id)
 
         self.beginResetModel()
         self.versions = model["file"]["versions"][::-1]

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -58,7 +58,7 @@ class WorkSpaceModel(QAbstractListModel):
 
         self.name = workspaceDict["name"]
         self.path = workspaceDict["path"]
-        self.subPath = ""
+        self.subPath = kwargs.get("subPath", "")
         self.files = []
 
         self.watcher = QFileSystemWatcher()

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -616,16 +616,18 @@ class FileItem:
         self.serverFileDict = serverFileDict
 
     def dump(self):
-        print(cleandoc(
-            f"""
-            name: {self.name}
-             ext: {self.ext}
-             path: {self.path}
-             is_folder: {self.is_folder}
-             versions: {self.versions}
-             current_version: {self.current_version}
-                   createdAt: {self.createdAt}
-             updatedAt: {self.updatedAt}
-             status: {self.status}
-             serverFileDict: {self.serverFileDict}"""
-        ))
+        print(
+            cleandoc(
+                f"""
+                name: {self.name}
+                 ext: {self.ext}
+                 path: {self.path}
+                 is_folder: {self.is_folder}
+                 versions: {self.versions}
+                 current_version: {self.current_version}
+                       createdAt: {self.createdAt}
+                 updatedAt: {self.updatedAt}
+                 status: {self.status}
+                 serverFileDict: {self.serverFileDict}"""
+            )
+        )

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -446,15 +446,17 @@ class ServerWorkspaceModel(WorkSpaceModel):
                 FreeCAD.loadFile(file_path)
 
     def deleteFile(self, index):
-        file_item = self.files[index.row()]
-        if (
-            file_item.serverFileDict is not None
-            and "modelId" in file_item.serverFileDict
-        ):
-            self.API_Client.deleteModel(file_item.serverFileDict["modelId"])
-        else:
-            self.API_Client.deleteFile(file_item.serverFileDict["_id"])
-        super().deleteFile(index)
+        # TODO: awaiting further instructions
+        # file_item = self.files[index.row()]
+        # if (
+        #     file_item.serverFileDict is not None
+        #     and "modelId" in file_item.serverFileDict
+        # ):
+        #     self.API_Client.deleteModel(file_item.serverFileDict["modelId"])
+        # else:
+        #     self.API_Client.deleteFile(file_item.serverFileDict["_id"])
+        # super().deleteFile(index)
+        pass
 
     def downloadFile(self, index):
         # This will download the latest version.

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -521,17 +521,19 @@ class ServerWorkspaceModel(WorkSpaceModel):
 
         self.API_Client.uploadFileToServer(uniqueName, file_path)
 
+        currentDir = self.currentDirectory[-1]
+        workspace = self.summarizeWorkspace()
+
         if create:
-            # First time the file is uploaded.
+            result = self.API_Client.createFile(fileName, fileUpdateDate, uniqueName, currentDir, workspace)
+            fileId = result["_id"]
             if extension.lower() in [".fcstd", ".obj"]:
-                self.API_Client.createModel(fileName, fileUpdateDate, uniqueName)
-            else:
-                self.API_Client.createFile(fileName, fileUpdateDate, uniqueName)
+                # TODO: This creates a file in the root directory as well
+                self.API_Client.createModel(fileName, uniqueName, fileId)
         else:
+            self.API_Client.updateFileObj(id_, fileUpdateDate, uniqueName, currentDir, workspace)
             if extension.lower() in [".fcstd", ".obj"]:
                 self.API_Client.regenerateModelObj(id_, fileUpdateDate, uniqueName)
-            else:
-                self.API_Client.updateFileObj(id_, fileUpdateDate, uniqueName)
 
     def openParentFolder(self):
         self.subPath = os.path.dirname(self.subPath)
@@ -545,14 +547,14 @@ class ServerWorkspaceModel(WorkSpaceModel):
                 [itemDict['custFileName'] for itemDict in serverDirDict['files']] +
                 [itemDict['name'] for itemDict in serverDirDict['directories']])
 
+    def summarizeWorkspace(self):
+        return {k: self.workspace[k] for k in ("_id", "name", "refName")}
+
     def createDir(self, dir):
         currentDir = self.currentDirectory[-1]
-        result = self.API_Client.createDirectory(dir, currentDir,
-                                                 self.workspace['_id'],
-                                                 self.workspace['name'],
-                                                 self.workspace['refName'])
-        from pprint import pprint
-        pprint(result)
+        workspace = self.summarizeWorkspace()
+        result = self.API_Client.createDirectory(dir, currentDir["_id"], workspace)
+
         return result
 
 

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -432,8 +432,14 @@ class ServerWorkspaceModel(WorkSpaceModel):
         file_item = self.files[index.row()]
         if file_item.is_folder:
             self.subPath = Utils.joinPath(self.subPath, file_item.name)
-            # push the new directory to the stack
-            self.currentDirectory.append(file_item.serverFileDict)
+            # push the directory to the stack
+            if file_item.serverFileDict.get("_id"):
+                # the server knows about this directory
+                self.currentDirectory.append(file_item.serverFileDict)
+            else:
+                # the server needs to know about this directory
+                id = self.createDir(file_item.name)
+                self.currentDirectory.append({"_id": id, "name": file_item.name})
             print(f"just appended: {self.currentDirectory}")
             self.refreshModel()
         else:

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -18,6 +18,10 @@ import shutil
 import uuid
 import requests
 
+from inspect import cleandoc
+
+from DataModels import CACHE_PATH
+
 
 # class WorkSpaceModelFactory:
 #    @staticmethod
@@ -57,7 +61,7 @@ class WorkSpaceModel(QAbstractListModel):
         self._id = workspaceDict["_id"]
 
         self.name = workspaceDict["name"]
-        self.path = workspaceDict["path"]
+        self.path = CACHE_PATH + self._id
         self.subPath = kwargs.get("subPath", "")
         self.files = []
 
@@ -483,7 +487,8 @@ class ServerWorkspaceModel(WorkSpaceModel):
         msg_box = QMessageBox()
         msg_box.setWindowTitle("Confirmation")
         msg_box.setText(
-            "The server version is newer than your local copy. Uploading will override the server version.\nAre you sure you want to proceed?"
+            "The server version is newer than your local copy. Uploading will "
+            "override the server version.\nAre you sure you want to proceed?"
         )
         msg_box.setIcon(QMessageBox.Warning)
         msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
@@ -532,8 +537,8 @@ class ServerWorkspaceModel(WorkSpaceModel):
             self.refreshModel(False)
 
     def upload(self, fileName, fileId=None):
-        # unique file name is always generated even if file is already on the server under another uniqueFileName.
-        # fileId is only used for updates
+        # unique file name is always generated even if file is already on the
+        # server under another uniqueFileName.  fileId is only used for updates
         base, extension = os.path.splitext(fileName)
         uniqueName = f"{str(uuid.uuid4())}.fcstd"  # TODO replace .fcstd by {extension}
 
@@ -611,6 +616,16 @@ class FileItem:
         self.serverFileDict = serverFileDict
 
     def dump(self):
-        print(
-            f"name: {self.name} \n ext: {self.ext} \n path: {self.path} \n is_folder: {self.is_folder} \n versions: {self.versions} \n current_version: {self.current_version} \n      createdAt: {self.createdAt} \n updatedAt: {self.updatedAt} \n status: {self.status} \n serverFileDict: {self.serverFileDict}"
-        )
+        print(cleandoc(
+            f"""
+            name: {self.name}
+             ext: {self.ext}
+             path: {self.path}
+             is_folder: {self.is_folder}
+             versions: {self.versions}
+             current_version: {self.current_version}
+                   createdAt: {self.createdAt}
+             updatedAt: {self.updatedAt}
+             status: {self.status}
+             serverFileDict: {self.serverFileDict}"""
+        ))

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -558,7 +558,9 @@ class ServerWorkspaceModel(WorkSpaceModel):
                 fileId, fileUpdateDate, uniqueName, currentDir, workspace
             )
             if extension.lower() in [".fcstd", ".obj"]:
-                self.API_Client.regenerateModelObj(result["modelId"], fileUpdateDate, uniqueName)
+                self.API_Client.regenerateModelObj(
+                    result["modelId"], fileUpdateDate, uniqueName
+                )
 
     def openParentFolder(self):
         self.subPath = os.path.dirname(self.subPath)

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -548,8 +548,13 @@ class ServerWorkspaceModel(WorkSpaceModel):
 
     def createDir(self, dir):
         currentDir = self.currentDirectory[-1]
-        self.API_Client.createDirectory(dir, currentDir['_id'],
-                                        self.workspace['_id'], self.workspace['name'])
+        result = self.API_Client.createDirectory(dir, currentDir,
+                                                 self.workspace['_id'],
+                                                 self.workspace['name'],
+                                                 self.workspace['refName'])
+        from pprint import pprint
+        pprint(result)
+        return result
 
 
 class FileItem:

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -365,7 +365,9 @@ class ServerWorkspaceModel(WorkSpaceModel):
 
         localDirs, localFiles = self.getLocalFiles()
         dirs = self.mergeFiles(serverDirs, localDirs, updateDirFound, updateDirNotFound)
-        files = self.mergeFiles(serverFiles, localFiles, updateFileFound, updateFileNotFound)
+        files = self.mergeFiles(
+            serverFiles, localFiles, updateFileFound, updateFileNotFound
+        )
 
         self.beginResetModel()
         self.files = self.sortFiles(dirs, files)
@@ -432,7 +434,7 @@ class ServerWorkspaceModel(WorkSpaceModel):
             self.subPath = Utils.joinPath(self.subPath, file_item.name)
             # push the new directory to the stack
             self.currentDirectory.append(file_item.serverFileDict)
-            print(f'just appended: {self.currentDirectory}')
+            print(f"just appended: {self.currentDirectory}")
             self.refreshModel()
         else:
             file_path = Utils.joinPath(self.getFullPath(), file_item.name)
@@ -527,27 +529,33 @@ class ServerWorkspaceModel(WorkSpaceModel):
         workspace = self.summarizeWorkspace()
 
         if create:
-            result = self.API_Client.createFile(fileName, fileUpdateDate, uniqueName, currentDir, workspace)
+            result = self.API_Client.createFile(
+                fileName, fileUpdateDate, uniqueName, currentDir, workspace
+            )
             fileId = result["_id"]
             if extension.lower() in [".fcstd", ".obj"]:
                 # TODO: This creates a file in the root directory as well
                 self.API_Client.createModel(fileName, uniqueName, fileId)
         else:
-            self.API_Client.updateFileObj(id_, fileUpdateDate, uniqueName, currentDir, workspace)
+            self.API_Client.updateFileObj(
+                id_, fileUpdateDate, uniqueName, currentDir, workspace
+            )
             if extension.lower() in [".fcstd", ".obj"]:
                 self.API_Client.regenerateModelObj(id_, fileUpdateDate, uniqueName)
 
     def openParentFolder(self):
         self.subPath = os.path.dirname(self.subPath)
-        print(f'popping {self.currentDirectory.pop()}')
+        print(f"popping {self.currentDirectory.pop()}")
         self.refreshModel()
 
     def getFileNames(self):
         currentDir = self.currentDirectory[-1]
         serverDirDict = self.API_Client.getDirectory(currentDir["_id"])
-        return (super().getFileNames() +
-                [itemDict['custFileName'] for itemDict in serverDirDict['files']] +
-                [itemDict['name'] for itemDict in serverDirDict['directories']])
+        return (
+            super().getFileNames()
+            + [itemDict["custFileName"] for itemDict in serverDirDict["files"]]
+            + [itemDict["name"] for itemDict in serverDirDict["directories"]]
+        )
 
     def summarizeWorkspace(self):
         return {k: self.workspace[k] for k in ("_id", "name", "refName")}

--- a/WorkSpace.py
+++ b/WorkSpace.py
@@ -403,10 +403,9 @@ class ServerWorkspaceModel(WorkSpaceModel):
                 file_item.serverFileDict is not None
                 and "modelId" in file_item.serverFileDict
                 and file_item.serverFileDict["modelId"] == fileId
-                and "model" in file_item.serverFileDict
-                and "thumbnailUrlCache" in file_item.serverFileDict["model"]
+                and "thumbnailUrlCache" in file_item.serverFileDict
             ):
-                thumbnailUrl = file_item.serverFileDict["model"]["thumbnailUrlCache"]
+                thumbnailUrl = file_item.serverFileDict["thumbnailUrlCache"]
                 try:
                     response = requests.get(thumbnailUrl)
                     image_data = response.content

--- a/Workspace.py
+++ b/Workspace.py
@@ -394,16 +394,16 @@ class ServerWorkspaceModel(WorkspaceModel):
             serverDate = serverFileItem.updatedAt
             localDate = localFileItem.updatedAt
             if serverDate < localDate:
-                logger.debug(f"serverDate updated: {serverDate}")
-                logger.debug(f"serverCreated: {serverFileItem.createdAt}")
-                logger.debug(f"localDate updated: {localDate}")
-                logger.debug(f"localCreated: {localFileItem.createdAt}")
+                # logger.debug(f"serverDate updated: {serverDate}")
+                # logger.debug(f"serverCreated: {serverFileItem.createdAt}")
+                # logger.debug(f"localDate updated: {localDate}")
+                # logger.debug(f"localCreated: {localFileItem.createdAt}")
                 serverFileItem.status = FileStatus.SERVER_COPY_OUTDATED
             elif serverDate > localDate:
-                logger.debug(f"serverDate updated: {serverDate}")
-                logger.debug(f"serverCreated: {serverFileItem.createdAt}")
-                logger.debug(f"localDate updated: {localDate}")
-                logger.debug(f"localCreated: {localFileItem.createdAt}")
+                # logger.debug(f"serverDate updated: {serverDate}")
+                # logger.debug(f"serverCreated: {serverFileItem.createdAt}")
+                # logger.debug(f"localDate updated: {localDate}")
+                # logger.debug(f"localCreated: {localFileItem.createdAt}")
                 serverFileItem.status = FileStatus.LOCAL_COPY_OUTDATED
             else:
                 serverFileItem.status = FileStatus.SYNCED
@@ -542,13 +542,16 @@ class ServerWorkspaceModel(WorkspaceModel):
         # Throws an APIClientException
         if fileItem.is_folder:
             logger.warn("Download of folders not supported yet.")
+            self.refreshModel()
+            return False
         else:
             logger.info(f"Downloading file {fileItem.name}")
             file_path = fileItem.getPath()
             self.apiClient.downloadFileFromServer(version["uniqueFileName"], file_path)
             updatedAt, createdAt = VersionModel.getVersionDateTime(version)
             Utils.setFileModificationTimes(file_path, updatedAt, createdAt)
-        self.refreshModel()
+            self.refreshModel()
+            return True
 
     def uploadUntrackedFiles(self):
         # This function upload untracked files automatically to Server.

--- a/Workspace.py
+++ b/Workspace.py
@@ -536,7 +536,7 @@ class ServerWorkspaceModel(WorkspaceModel):
         # This will download the current (active) version.
         # Throws an APIClientException
 
-        logger.info("Downloading file...")
+        logger.info(f"Downloading file {file_item.name}")
         if file_item.is_folder:
             logger.warn("Download of folders not supported yet.")
         else:
@@ -563,8 +563,6 @@ class ServerWorkspaceModel(WorkspaceModel):
         return msg_box.exec_() == QMessageBox.Yes
 
     def uploadFile(self, index):
-        print("uploading file...")
-
         file_item = self.files[index.row()]
         if file_item.is_folder:
             print("Upload of folders not supported yet.")
@@ -622,6 +620,7 @@ class ServerWorkspaceModel(WorkspaceModel):
 
         # raises APIClientException
 
+        logger.info(f"Uploading file {fileName}")
         base, extension = os.path.splitext(fileName)
         uniqueName = f"{str(uuid.uuid4())}.fcstd"  # TODO replace .fcstd by {extension}
 
@@ -637,8 +636,9 @@ class ServerWorkspaceModel(WorkspaceModel):
             result = self.apiClient.updateFileObj(
                 fileId, fileUpdateDate, uniqueName, currentDir, workspace
             )
-            if extension.lower() in [".fcstd", ".obj"]:
-                self.apiClient.regenerateModelObj(result["modelId"], fileId)
+            # no longer needed
+            # if extension.lower() in [".fcstd", ".obj"]:
+            #     self.apiClient.regenerateModelObj(result["modelId"], fileId)
         else:
             result = self.apiClient.createFile(
                 fileName, fileUpdateDate, uniqueName, currentDir, workspace

--- a/Workspace.py
+++ b/Workspace.py
@@ -47,11 +47,11 @@ class FileStatus(Enum):
     def __str__(self):
         match self:
             case FileStatus.SERVER_ONLY:
-                return "Server only"
+                return "Not downloaded"
             case FileStatus.SERVER_COPY_OUTDATED:
-                return "Server copy outdated"
+                return "Local copy newer"
             case FileStatus.LOCAL_COPY_OUTDATED:
-                return "Local copy outdated"
+                return "Lens copy newer"
             case FileStatus.SYNCED:
                 return "Synced"
             case FileStatus.UNTRACKED:

--- a/Workspace.py
+++ b/Workspace.py
@@ -48,12 +48,18 @@ class FileStatus(Enum):
 
     def __str__(self):
         match self:
-            case FileStatus.SERVER_ONLY: return "Server only"
-            case FileStatus.LOCAL_ONLY: return "Local only"
-            case FileStatus.SERVER_COPY_OUTDATED: return "Server copy outdated"
-            case FileStatus.LOCAL_COPY_OUTDATED: return "Local copy outdated"
-            case FileStatus.SYNCED: return "Synced"
-            case FileStatus.UNTRACKED: return "Untracked"
+            case FileStatus.SERVER_ONLY:
+                return "Server only"
+            case FileStatus.LOCAL_ONLY:
+                return "Local only"
+            case FileStatus.SERVER_COPY_OUTDATED:
+                return "Server copy outdated"
+            case FileStatus.LOCAL_COPY_OUTDATED:
+                return "Local copy outdated"
+            case FileStatus.SYNCED:
+                return "Synced"
+            case FileStatus.UNTRACKED:
+                return "Untracked"
             case _:
                 logger.error(f"Unknown file status: {self}")
                 return "Unknown"
@@ -317,9 +323,7 @@ class ServerWorkspaceModel(WorkspaceModel):
         createdDate = currentVersion["createdAt"]
         hasFileUpdatedAt = "fileUpdatedAt" in currentVersion["additionalData"]
         logger.debug(f"has fileUpdatedAt? {hasFileUpdatedAt}")
-        updatedDate = currentVersion["additionalData"].get(
-            "fileUpdatedAt", createdDate
-        )
+        updatedDate = currentVersion["additionalData"].get("fileUpdatedAt", createdDate)
         return updatedDate, createdDate
 
     def getServerFiles(self, serverFileDicts):
@@ -557,8 +561,10 @@ class ServerWorkspaceModel(WorkspaceModel):
                     return
                 else:
                     self.upload(file_item.name, file_item.serverFileDict["_id"])
-            elif (file_item.status is FileStatus.UNTRACKED or
-                  file_item.status is FileStatus.LOCAL_ONLY):
+            elif (
+                file_item.status is FileStatus.UNTRACKED
+                or file_item.status is FileStatus.LOCAL_ONLY
+            ):
                 self.upload(file_item.name)
             elif file_item.status is FileStatus.SERVER_COPY_OUTDATED:
                 self.upload(file_item.name, file_item.serverFileDict["_id"])

--- a/Workspace.py
+++ b/Workspace.py
@@ -527,12 +527,11 @@ class ServerWorkspaceModel(WorkspaceModel):
         self.refreshModel()
 
     def getFileItemFileId(self, fileId):
-        try:
-            indexFileId = [fi.serverFileDict["_id"] for fi in self.files].index(fileId)
-        except ValueError:
-            logger.error("Cannot find the correct fileId")
-            return None
-        return self.files[indexFileId]
+        for fi in self.files:
+            if fi.serverFileDict and fi.serverFileDict["_id"] == fileId:
+                return fi
+        logger.error("Cannot find the correct fileId")
+        return None
 
     def downloadFile(self, fileItem):
         # This will download the current (active) version.

--- a/Workspace.py
+++ b/Workspace.py
@@ -630,7 +630,9 @@ class ServerWorkspaceModel(WorkspaceModel):
         # raises an APIClientException
         currentDir = self.currentDirectory[-1]
         workspace = self.summarizeWorkspace()
-        result = self.apiClient.createDirectory(dir, currentDir["_id"], workspace)
+        result = self.apiClient.createDirectory(
+            dir, currentDir["_id"], currentDir["name"], workspace
+        )
 
         return result
 

--- a/Workspace.py
+++ b/Workspace.py
@@ -589,8 +589,12 @@ class ServerWorkspaceModel(WorkspaceModel):
                 logger.debug(f"Upload untracked file {file_item.name}")
                 self.upload(file_item.name)
             elif file_item.status is FileStatus.SERVER_COPY_OUTDATED:
-                logger.debug(f"Upload outdated file {file_item.name}")
+                logger.debug(
+                    f"Upload a file {file_item.name} that is outdated on the server"
+                )
                 self.upload(file_item.name, file_item.serverFileDict["_id"])
+            elif file_item.status is FileStatus.SYNCED:
+                logger.info(f"File {file_item.name} is already in sync")
             else:
                 logger.error(f"Unknown file status: {file_item.status}")
         self.refreshModel()

--- a/Workspace.py
+++ b/Workspace.py
@@ -720,6 +720,12 @@ class FileItem:
     def getPath(self):
         return Utils.joinPath(self.path, self.name)
 
+    def getModelId(self):
+        if self.serverFileDict and "modelId" in self.serverFileDict:
+            return self.serverFileDict["modelId"]
+        else:
+            return None
+
     def dump(self):
         print(
             cleandoc(

--- a/Workspace.py
+++ b/Workspace.py
@@ -385,11 +385,11 @@ class ServerWorkspaceModel(WorkspaceModel):
         # O(n^2) can be made more efficient with sorting and parallel iteration
         # for now it suffices
         for localFile in localFiles:
-            # print(f'serverFile: {localFile.name}')
+            # logger.debug(f'serverFile: {localFile.name}')
             for serverFile in serverFiles:
-                # print(f'localFile: {serverFile.name}')
+                # logger.debug(f'localFile: {serverFile.name}')
                 if serverFile.name == localFile.name:
-                    # print(f'found {serverFile.name} locally')
+                    # logger.debug(f'found {serverFile.name} locally')
                     funcUpdateFound(serverFile, localFile)
                     break
             else:  # the server does not have this file

--- a/Workspace.py
+++ b/Workspace.py
@@ -191,7 +191,11 @@ class WorkspaceModel(QAbstractListModel):
         pathDir = Utils.joinPath(self.getFullPath(), dirName)
         if os.path.isdir(pathDir):
             files = os.listdir(pathDir)
-            return not files
+            return not files or (
+                len(files) == 1
+                and files[0] == ".thumbnails"
+                and os.path.isdir(Utils.joinPath(pathDir, files[0]))
+            )
         elif os.path.isfile(pathDir):
             raise ValueError(f"{dirName} is not a directory but a file")
         else:

--- a/Workspace.py
+++ b/Workspace.py
@@ -421,8 +421,11 @@ class ServerWorkspaceModel(WorkspaceModel):
         self.files = self.sortFiles(dirs, files)
         self.endResetModel()
 
-        if firstCall:
-            self.uploadUntrackedFiles()
+        # This needs to be disabled unless we maintain our own file administration.
+        # If a file is deleted on the server, the addon will automatically add it to
+        # the server again by means of this call.
+        # if firstCall:
+        #     self.uploadUntrackedFiles()
 
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
@@ -510,18 +513,18 @@ class ServerWorkspaceModel(WorkspaceModel):
                 logger.debug(f"is openable file path: {file_path}")
                 FreeCAD.loadFile(file_path)
 
+    def deleteFileLocally(self, index):
+        super().deleteFile(index)
+        self.refreshModel()
+
     def deleteFile(self, index):
-        # TODO: awaiting further instructions
-        # file_item = self.files[index.row()]
-        # if (
-        #     file_item.serverFileDict is not None
-        #     and "modelId" in file_item.serverFileDict
-        # ):
-        #     self.apiClient.deleteModel(file_item.serverFileDict["modelId"])
-        # else:
-        #     self.apiClient.deleteFile(file_item.serverFileDict["_id"])
-        # super().deleteFile(index)
-        pass
+        """Delete a file from the server.
+
+        This function assumes that the files have been removed locally.
+        """
+        file_item = self.files[index.row()]
+        self.apiClient.deleteFile(file_item.serverFileDict["_id"])
+        self.refreshModel()
 
     def getFileItemFileId(self, fileId):
         try:

--- a/Workspace.py
+++ b/Workspace.py
@@ -519,7 +519,8 @@ class ServerWorkspaceModel(WorkspaceModel):
                     pass  # no thumbnail online.
         return None
 
-    def openDirectory(self, file_item):
+    def openDirectory(self, index):
+        file_item = self.files[index.row()]
         self.subPath = Utils.joinPath(self.subPath, file_item.name)
         # push the directory to the stack
         if file_item.serverFileDict.get("_id"):

--- a/Workspace.py
+++ b/Workspace.py
@@ -681,15 +681,15 @@ class ServerWorkspaceModel(WorkspaceModel):
     def summarizeWorkspace(self):
         return {k: self.workspace[k] for k in ("_id", "name", "refName")}
 
-    def createDir(self, dir):
+    def createDir(self, nameDirectory):
         # raises an APIClientException
         currentDir = self.currentDirectory[-1]
         workspace = self.summarizeWorkspace()
         result = self.apiClient.createDirectory(
-            dir, currentDir["_id"], currentDir["name"], workspace
+            nameDirectory, currentDir["_id"], currentDir["name"], workspace
         )
 
-        return result
+        return result["_id"]
 
 
 class FileItem:

--- a/Workspace.py
+++ b/Workspace.py
@@ -23,7 +23,7 @@ from inspect import cleandoc
 from DataModels import CACHE_PATH
 
 
-# class WorkSpaceModelFactory:
+# class WorkspaceModelFactory:
 #    @staticmethod
 #    def createWorkspace(workspaceDict, **kwargs):
 #        if workspaceDict["type"] == "Ondsel":
@@ -43,7 +43,7 @@ class TokenRefreshThread(QThread):
             self.sleep(600)
 
 
-class WorkSpaceModel(QAbstractListModel):
+class WorkspaceModel(QAbstractListModel):
     NameRole = Qt.UserRole + 1
     NameAndIsFolderRole = Qt.UserRole + 2
     IdRole = Qt.UserRole + 3
@@ -159,7 +159,7 @@ class WorkSpaceModel(QAbstractListModel):
         }
 
     def deleteFile(self, index):
-        fileName = self.data(index, WorkSpaceModel.NameRole)
+        fileName = self.data(index, WorkspaceModel.NameRole)
 
         fileName = Utils.joinPath(self.getFullPath(), fileName)
         if os.path.isfile(fileName):
@@ -192,7 +192,7 @@ class WorkSpaceModel(QAbstractListModel):
             print(file)
 
 
-class LocalWorkspaceModel(WorkSpaceModel):
+class LocalWorkspaceModel(WorkspaceModel):
     def __init__(self, workspaceDict, **kwargs):
         super().__init__(workspaceDict, **kwargs)
 
@@ -242,7 +242,7 @@ class LocalWorkspaceModel(WorkSpaceModel):
                 FreeCAD.loadFile(file_path)
 
 
-class ServerWorkspaceModel(WorkSpaceModel):
+class ServerWorkspaceModel(WorkspaceModel):
     def __init__(self, workspaceDict, **kwargs):
         super().__init__(workspaceDict, **kwargs)
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -22,7 +22,7 @@ import FreeCAD
 import FreeCADGui as Gui
 
 
-from DataModels import WorkspaceListModel
+from DataModels import WorkspaceListModel, CACHE_PATH
 from VersionModel import OndselVersionModel
 from LinkModel import ShareLinkModel
 from APIClient import APIClient, APIClientException, APIClientAuthenticationException
@@ -1252,13 +1252,20 @@ class WorkspaceView(QtGui.QDockWidget):
         p.SetString("loginData", "")
         self.access_token = None
         self.apiClient = None
+        self.user = None
 
         if self.currentWorkspaceModel:
             self.setWorkspaceModel()
 
-        # self.leaveWorkspace()
-
-        # self.workspacesModel.removeOndselWorkspaces()
+        if p.GetBool("clearCache", False):
+            shutil.rmtree(CACHE_PATH)
+            self.currentWorkspace = None
+            self.currentWorkspaceModel = None
+            self.form.fileList.setModel(None)
+            self.workspacesModel.removeWorkspaces()
+            self.switchView()
+            self.form.workspaceNameLabel.setText("")
+            self.form.fileDetails.setVisible(False)
 
     def timerTick(self):
         def tryRefresh():

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -25,7 +25,7 @@ import FreeCADGui as Gui
 from DataModels import WorkspaceListModel
 from VersionModel import OndselVersionModel
 from LinkModel import ShareLinkModel
-from APIClient import APIClient, CustomAuthenticationError
+from APIClient import APIClient, APIClientAuthenticationException
 from Workspace import (
     WorkspaceModel,
     LocalWorkspaceModel,
@@ -1095,8 +1095,8 @@ class WorkspaceView(QtGui.QDockWidget):
                 try:
                     self.apiClient = APIClient(email, password, baseUrl, lensUrl)
                     self.apiClient._authenticate()
-                except CustomAuthenticationError as e:
-                    print("Handling authentication error:", str(e))
+                except APIClientAuthenticationException as e:
+                    logger.warn(str(e))
                     continue  # Present the login dialog again if authentication fails
                 # Check if the request was successful (201 status code)
                 if self.apiClient.access_token is not None:
@@ -1117,7 +1117,7 @@ class WorkspaceView(QtGui.QDockWidget):
                     # Set a timer to logout when token expires.
                     self.setTokenExpirationTimer(self.access_token)
                 else:
-                    print("Authentication failed")
+                    logger.warn("Authentication failed")
                 break
             else:
                 break  # Exit the login loop if the dialog is canceled

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -585,6 +585,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.currentWorkspace = None
         self.currentWorkspaceModel = None
         self.form.fileList.setModel(None)
+        self.workspacesModel.refreshModel()
         self.switchView()
         self.form.workspaceNameLabel.setText("")
         self.form.fileDetails.setVisible(False)

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1629,12 +1629,19 @@ class SharingLinkEditDialog(QtGui.QDialog):
 
     def setLinkProperties(self):
         self.dialog.linkName.setText(self.linkProperties["description"])
+        self.dialog.canViewModelCheckBox.setChecked(
+            self.linkProperties["canViewModel"]
+        )
         self.dialog.canViewModelAttributesCheckBox.setChecked(
             self.linkProperties["canViewModelAttributes"]
         )
-        self.dialog.canUpdateModelCheckBox.setChecked(
+        self.dialog.canUpdateModelAttributesCheckBox.setChecked(
             self.linkProperties["canUpdateModel"]
         )
+        self.dialog.canDownloadOriginalCheckBox.setChecked(
+            self.linkProperties["canDownloadDefaultModel"]
+        )
+
         self.dialog.canExportFCStdCheckBox.setChecked(
             self.linkProperties["canExportFCStd"]
         )
@@ -1647,11 +1654,15 @@ class SharingLinkEditDialog(QtGui.QDialog):
     def getLinkProperties(self):
         self.linkProperties["description"] = self.dialog.linkName.text()
         self.linkProperties[
+            "canViewModel"
+        ] = self.dialog.canViewModelCheckBox.isChecked()
+        self.linkProperties[
             "canViewModelAttributes"
         ] = self.dialog.canViewModelAttributesCheckBox.isChecked()
         self.linkProperties[
             "canUpdateModel"
-        ] = self.dialog.canUpdateModelCheckBox.isChecked()
+        ] = self.dialog.canUpdateModelAttributesCheckBox.isChecked()
+
         self.linkProperties[
             "canExportFCStd"
         ] = self.dialog.canExportFCStdCheckBox.isChecked()

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -879,7 +879,8 @@ class WorkspaceView(QtGui.QDockWidget):
             self.currentWorkspaceModel.downloadFile(index)
         elif action == uploadAction:
             self.currentWorkspaceModel.uploadFile(index)
-            self.form.versionsComboBox.model().refreshModel()
+            if self.form.versionsComboBox.isVisible():
+                self.form.versionsComboBox.model().refreshModel()
 
     def showFileContextMenuDir(self, pos, index):
         menu = QtGui.QMenu()

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -890,6 +890,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.form.thumbnail_label.setPixmap(pixmap)
 
     def fileListClickedLoggedIn(self, file_item):
+        logger.debug("fileListClickedLoggedOut")
         fileName = file_item.name
         if "modelId" in file_item.serverFileDict:
             # currentModelId is used for the server model and is necessary to
@@ -945,6 +946,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.form.fileDetails.setVisible(False)
 
     def fileListClickedLoggedOut(self, fileName):
+        logger.debug("fileListClickedLoggedOut")
         path = self.currentWorkspaceModel.getFullPath()
         pixmap = Utils.extract_thumbnail(f"{path}/{fileName}")
         if pixmap:
@@ -1195,7 +1197,7 @@ class WorkspaceView(QtGui.QDockWidget):
             elif fileItem.status is FileStatus.UNTRACKED:
                 logger.debug(f"Upload untracked file {fileItem.name}")
                 # Initial commit
-                self.upload(fileItem, fileItem.name)
+                self.uploadFile(fileItem, fileItem.name)
             elif fileItem.status is FileStatus.SERVER_COPY_OUTDATED:
                 self.uploadWithCommitMessage(fileItem, "that is outdated on the server")
             elif fileItem.status is FileStatus.SYNCED:

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -858,7 +858,8 @@ class WorkspaceView(QtGui.QDockWidget):
             wsm.refreshModel()
             return
         wsm.downloadFile(fileItem)
-        self.updateThumbnail(fileItem)
+        if Utils.isOpenableByFreeCAD(fileItem.getPath()):
+            self.updateThumbnail(fileItem)
 
     def restoreFile(self, fileItem):
         # iterate over the files
@@ -991,7 +992,7 @@ class WorkspaceView(QtGui.QDockWidget):
         file_item = self.currentWorkspaceModel.data(index)
         fileName = file_item.name
         # self.currentModelId = None
-        if Utils.isOpenableByFreeCAD(fileName):
+        if Utils.isOpenableByFreeCAD(file_item.getPath()):
             if self.isLoggedIn():
                 self.fileListClickedLoggedIn(file_item)
             else:

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -733,42 +733,6 @@ class WorkspaceView(QtGui.QDockWidget):
         fileName = self.currentWorkspaceModel.data(idx, WorkspaceModel.NameRole)
         fullFileName = f"{self.currentWorkspace['url']}/{fileName}"
 
-        """if self.currentWorkspace["type"] == "Local":
-            backupfilename = model.data(index, role=QtCore.Qt.UserRole)
-
-            # Process the user's choice
-            if choice == QMessageBox.Save:
-                # make sure the document is open and get a reference
-                doc = FreeCAD.open(fullFileName)
-
-                # create a temporary copy of the backup so it isn't lost by backup
-                # policy
-                temp_dir = tempfile.gettempdir()
-                temp_file = tempfile.NamedTemporaryFile(dir=temp_dir, delete=False)
-                temp_file_path = temp_file.name
-                temp_file.close()
-
-                shutil.copy(backupfilename, temp_file_path)
-
-                # Save and close the original to create the new backup
-                doc.save()
-                FreeCAD.closeDocument(doc.Name)
-
-                # move the tempfile back to the original
-                try:
-                    shutil.move(temp_file_path, fullFileName)
-                except OSError as e:
-                    print(f"Error renaming file: {e}")
-                # reopen the original
-                doc = FreeCAD.open(fullFileName)
-            elif choice == QMessageBox.Discard:
-                try:
-                    shutil.move(backupfilename, fullFileName)
-                except OSError as e:
-                    print(f"Error renaming file: {e}")
-                doc = FreeCAD.open(fullFileName)
-                doc.restore()
-        elif self.currentWorkspace["type"] == "Ondsel":"""
         versionUniqueFileName = model.data(index, role=QtCore.Qt.UserRole)
 
         # Process the user's choice

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -26,7 +26,7 @@ from DataModels import WorkspaceListModel, CACHE_PATH
 from VersionModel import LocalVersionModel, OndselVersionModel
 from LinkModel import ShareLinkModel
 from APIClient import APIClient, CustomAuthenticationError
-from WorkSpace import WorkSpaceModel, LocalWorkspaceModel, ServerWorkspaceModel
+from Workspace import WorkspaceModel, LocalWorkspaceModel, ServerWorkspaceModel
 
 from PySide.QtGui import (
     QStyledItemDelegate,
@@ -81,7 +81,7 @@ class FileListDelegate(QStyledItemDelegate):
             return
 
         fileName, status, isFolder = index.data(
-            WorkSpaceModel.NameStatusAndIsFolderRole
+            WorkspaceModel.NameStatusAndIsFolderRole
         )
 
         if option.state & QStyle.State_Selected:
@@ -673,7 +673,7 @@ class WorkspaceView(QtGui.QDockWidget):
         index = model.index(row, 0)
 
         idx = self.form.fileList.currentIndex()
-        fileName = self.currentWorkspaceModel.data(idx, WorkSpaceModel.NameRole)
+        fileName = self.currentWorkspaceModel.data(idx, WorkspaceModel.NameRole)
         fullFileName = f"{self.currentWorkspace['url']}/{fileName}"
 
         """if self.currentWorkspace["type"] == "Local":

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -542,9 +542,9 @@ class WorkspaceView(QtGui.QDockWidget):
             subPath = ""
             if hasattr(self, "currentWorkspaceModel") and self.currentWorkspaceModel:
                 subPath = self.currentWorkspaceModel.subPath
-            self.currentWorkspaceModel = LocalWorkspaceModel(self.currentWorkspace,
-                                                             subPath=subPath)
-
+            self.currentWorkspaceModel = LocalWorkspaceModel(
+                self.currentWorkspace, subPath=subPath
+            )
 
         # Create a workspace model and set it to the list
         # if self.apiClient is None and self.access_token is None:
@@ -870,7 +870,7 @@ class WorkspaceView(QtGui.QDockWidget):
             if result == QtGui.QMessageBox.Yes:
                 self.currentWorkspaceModel.deleteFile(index)
         if action == openOnlineAction:
-            self.currentModelId = file_item.serverFileDict['modelId']
+            self.currentModelId = file_item.serverFileDict["modelId"]
             self.openModelOnline()
             self.currentModelId = None
         elif action == downloadAction:
@@ -895,7 +895,7 @@ class WorkspaceView(QtGui.QDockWidget):
             )
             if result == QtGui.QMessageBox.Yes:
                 self.currentWorkspaceModel.deleteFile(index)
-                
+
     def showFileContextMenu(self, pos):
         index = self.form.fileList.indexAt(pos)
         file_item = self.currentWorkspaceModel.data(index)
@@ -1123,7 +1123,7 @@ class WorkspaceView(QtGui.QDockWidget):
         default_file_path = Utils.joinPath(default_path, default_name)
 
         doc.FileName = default_file_path
-        Gui.SendMsgToActiveView('SaveAs')
+        Gui.SendMsgToActiveView("SaveAs")
 
         # Open a dialog box for the user to select a file location and name
         # file_name, _ = QtGui.QFileDialog.getSaveFileName(

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -480,7 +480,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.userMenu = QMenu(self.form.userBtn)
         userActions = QActionGroup(self.userMenu)
 
-        a = QAction("Ondsel Account", userActions)
+        a = QAction("Visit Ondsel Lens", userActions)
         a.triggered.connect(self.ondselAccount)
         self.userMenu.addAction(a)
 
@@ -892,7 +892,7 @@ class WorkspaceView(QtGui.QDockWidget):
     def fileListClickedLoggedIn(self, file_item):
         logger.debug("fileListClickedLoggedOut")
         fileName = file_item.name
-        if "modelId" in file_item.serverFileDict:
+        if file_item.serverFileDict and "modelId" in file_item.serverFileDict:
             # currentModelId is used for the server model and is necessary to
             # open models online
             self.currentModelId = file_item.serverFileDict["modelId"]

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -757,6 +757,17 @@ class WorkspaceView(QtGui.QDockWidget):
         wsm.downloadFile(fileItem)
         self.updateThumbnail(fileItem)
 
+    def restoreFile(self, fileId):
+        wsm = self.currentWorkspaceModel
+        fileItem = wsm.getFileItemFileId(fileId)
+        fileName = fileItem.name
+        path = fileItem.path
+
+        # iterate over the files
+        for doc in FreeCAD.listDocuments().values():
+            if doc.FileName == Utils.joinPath(path, fileName):
+                doc.restore()
+
     def versionClicked(self, row):
         # message_box = QMessageBox()
         # message_box.setWindowTitle("Confirmation")
@@ -788,6 +799,7 @@ class WorkspaceView(QtGui.QDockWidget):
             self.form.versionsComboBox.setCurrentIndex(versionModel.getCurrentIndex())
 
             self.downloadFileFileId(fileId)
+            self.restoreFile(fileId)
 
         self.handle(trySetVersionActive)
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -26,8 +26,12 @@ from DataModels import WorkspaceListModel
 from VersionModel import OndselVersionModel
 from LinkModel import ShareLinkModel
 from APIClient import APIClient, CustomAuthenticationError
-from Workspace import WorkspaceModel, LocalWorkspaceModel, \
-    ServerWorkspaceModel, FileStatus
+from Workspace import (
+    WorkspaceModel,
+    LocalWorkspaceModel,
+    ServerWorkspaceModel,
+    FileStatus,
+)
 
 from PySide.QtGui import (
     QStyledItemDelegate,
@@ -59,8 +63,10 @@ remote_changelog_url = (
     "https://github.com/Ondsel-Development/Ondsel-Lens/blob/master/changeLog.md"
 )
 
-remote_package_url = "https://raw.githubusercontent.com/Ondsel-Development/"\
+remote_package_url = (
+    "https://raw.githubusercontent.com/Ondsel-Development/"
     "Ondsel-Lens/master/package.xml"
+)
 local_package_path = f"{modPath}/package.xml"
 
 try:
@@ -372,18 +378,20 @@ class WorkspaceView(QtGui.QDockWidget):
 
         self.form.fileDetails.setVisible(False)
 
-        explainText = cleandoc("""
-        <h1 style="text-align:center; font-weight:bold;">Welcome</h1>
+        explainText = cleandoc(
+            """
+            <h1 style="text-align:center; font-weight:bold;">Welcome</h1>
 
-        <p>You're not currently logged in to the Ondsel service. Use the button above
-           to log in or create an account. When you log in, this space will show your
-           workspaces.
-        </p>
+            <p>You're not currently logged in to the Ondsel service. Use the button
+               above to log in or create an account. When you log in, this space will
+               show your workspaces.
+            </p>
 
-        <p>You can enter the workspaces by double-clicking them.</p>
+            <p>You can enter the workspaces by double-clicking them.</p>
 
-        <p>Each workspace is a collection of files. Think of it like a project.</p>
-        """)
+            <p>Each workspace is a collection of files. Think of it like a project.</p>
+            """
+        )
 
         self.form.txtExplain.setHtml(explainText)
         self.form.txtExplain.setReadOnly(True)

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1519,9 +1519,9 @@ class WorkspaceView(QtGui.QDockWidget):
 
         self.handle(tryRefresh)
 
-# ####
-# Adding files and directories
-# ####
+    # ####
+    # Adding files and directories
+    # ####
 
     def addCurrentFile(self):
         # Save current file on the server.

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1094,7 +1094,7 @@ class WorkspaceView(QtGui.QDockWidget):
         fileName = fileItem.name
         if fileItem.status == FileStatus.SERVER_ONLY:
             if self.confirmDeleteLens(fileName) == QtGui.QMessageBox.Yes:
-                self.currentWorkspaceModel.deleteFile(index)
+                self.handle(lambda: self.currentWorkspaceModel.deleteFile(index))
         elif fileItem.status in [
             FileStatus.UNTRACKED,
             FileStatus.LOCAL_COPY_OUTDATED,

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1069,18 +1069,23 @@ class WorkspaceView(QtGui.QDockWidget):
         default_path = self.currentWorkspaceModel.getFullPath()
         default_file_path = Utils.joinPath(default_path, default_name)
 
-        # Open a dialog box for the user to select a file location and name
-        file_name, _ = QtGui.QFileDialog.getSaveFileName(
-            self, "Save File", default_file_path, "FreeCAD file (*.fcstd)"
-        )
+        doc.FileName = default_file_path
+        Gui.SendMsgToActiveView('SaveAs')
 
-        if file_name:
-            # Make sure the file has the correct extension
-            if not file_name.lower().endswith(".fcstd"):
-                file_name += ".FCStd"
-            # Save the file
-            FreeCAD.Console.PrintMessage(f"Saving document to file: {file_name}\n")
-            doc.saveAs(file_name)
+        # Open a dialog box for the user to select a file location and name
+        # file_name, _ = QtGui.QFileDialog.getSaveFileName(
+        #     self, "Save File", default_file_path, "FreeCAD file (*.fcstd)"
+        # )
+
+        # if file_name:
+        #     # Make sure the file has the correct extension
+        #     if not file_name.lower().endswith(".fcstd"):
+        #         file_name += ".FCStd"
+        #     # Save the file
+        #     FreeCAD.Console.PrintMessage(f"Saving document to file: {file_name}\n")
+        #     doc.saveAs(file_name)
+        self.currentWorkspaceModel.refreshModel()
+        self.switchView()
 
     def addSelectedFiles(self):
         # open file browser dialog to select files to copy
@@ -1106,6 +1111,8 @@ class WorkspaceView(QtGui.QDockWidget):
                     QtGui.QMessageBox.warning(
                         None, "Error", "Failed to copy file " + fileName
                     )
+        self.currentWorkspaceModel.refreshModel()
+        self.switchView()
 
     def addDir(self):
         existingFileNames = self.currentWorkspaceModel.getFileNames()

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -187,8 +187,6 @@ class WorkspaceListDelegate(QStyledItemDelegate):
         if organizationData:
             organizationName = organizationData.get("name")
             if organizationName:
-                logger.debug("Got organization name")
-                logger.info("Got organization name")
                 return f"({organizationName})"
             else:
                 logger.debug("No 'name' in organization'")
@@ -783,7 +781,6 @@ class WorkspaceView(QtGui.QDockWidget):
     def fileListClickedLoggedOut(self, fileName):
         path = self.currentWorkspaceModel.getFullPath()
         pixmap = Utils.extract_thumbnail(f"{path}/{fileName}")
-        logger.debug(f"{path}/{fileName}")
         if pixmap:
             self.form.thumbnail_label.show()
             self.form.thumbnail_label.setFixedSize(pixmap.width(), pixmap.height())

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1108,13 +1108,12 @@ class WorkspaceView(QtGui.QDockWidget):
                 self.currentWorkspaceModel.getFullPath(), fileName
             )
 
-            if Utils.isOpenableByFreeCAD(fileName):
-                try:
-                    shutil.copy(fileUrl, destFileUrl)
-                except:
-                    QtGui.QMessageBox.warning(
-                        None, "Error", "Failed to copy file " + fileName
-                    )
+            try:
+                shutil.copy(fileUrl, destFileUrl)
+            except:
+                QtGui.QMessageBox.warning(
+                    None, "Error", "Failed to copy file " + fileName
+                )
         self.currentWorkspaceModel.refreshModel()
         self.switchView()
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -397,6 +397,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.switchView()
 
         self.workspacesModel.refreshModel()
+        self.currentWorkspaceModel = None
 
         # Set a timer to check regularly the server
         self.timer = QtCore.QTimer()
@@ -1094,7 +1095,8 @@ class WorkspaceView(QtGui.QDockWidget):
         self.access_token = None
         self.apiClient = None
 
-        self.setWorkspaceModel()
+        if self.currentWorkspaceModel:
+            self.setWorkspaceModel()
 
         # self.leaveWorkspace()
 

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -334,9 +334,10 @@ class WorkspaceView(QtGui.QDockWidget):
         self.form.workspaceListView.setItemDelegate(self.workspacesDelegate)
         self.form.workspaceListView.doubleClicked.connect(self.enterWorkspace)
         self.form.workspaceListView.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.form.workspaceListView.customContextMenuRequested.connect(
-            self.showWorkspaceContextMenu
-        )
+        # Disable this, prefer to do this in the dashboard
+        # self.form.workspaceListView.customContextMenuRequested.connect(
+        #     self.showWorkspaceContextMenu
+        # )
         self.workspacesModel.rowsInserted.connect(self.switchView)
         self.workspacesModel.rowsRemoved.connect(self.switchView)
 
@@ -466,9 +467,10 @@ class WorkspaceView(QtGui.QDockWidget):
         # self.synchronizeAction.setVisible(False)
         # self.userMenu.addAction(self.synchronizeAction)
 
-        self.newWorkspaceAction = QAction("Add new workspace", userActions)
-        self.newWorkspaceAction.triggered.connect(self.newWorkspaceBtnClicked)
-        self.userMenu.addAction(self.newWorkspaceAction)
+        # Prefer to do this in the dashboard
+        # self.newWorkspaceAction = QAction("Add new workspace", userActions)
+        # self.newWorkspaceAction.triggered.connect(self.newWorkspaceBtnClicked)
+        # self.userMenu.addAction(self.newWorkspaceAction)
 
         # Preferences
         submenu = QMenu("Preferences", self.userMenu)
@@ -624,14 +626,14 @@ class WorkspaceView(QtGui.QDockWidget):
         # self.synchronizeAction.triggered.connect(
         #     self.currentWorkspaceModel.refreshModel
         # )
-        self.newWorkspaceAction.setVisible(False)
+        # self.newWorkspaceAction.setVisible(False)
 
         self.switchView()
 
     def leaveWorkspace(self):
         if self.currentWorkspace is None:
             return
-        self.newWorkspaceAction.setVisible(True)
+        # self.newWorkspaceAction.setVisible(True)
         # self.synchronizeAction.setVisible(False)
         # self.synchronizeAction.triggered.disconnect()
         self.currentWorkspace = None
@@ -879,39 +881,42 @@ class WorkspaceView(QtGui.QDockWidget):
             self.form.versionsComboBox.setModel(model)
             self.form.versionsComboBox.setVisible(True)
 
-    # TODO allow deleting workspace?
-    def showWorkspaceContextMenu(self, pos):
-        index = self.form.workspaceListView.indexAt(pos)
+    # def showWorkspaceContextMenu(self, pos):
+    #     index = self.form.workspaceListView.indexAt(pos)
 
-        if index.isValid():
-            menu = QtGui.QMenu()
+    #     if index.isValid():
+    #         menu = QtGui.QMenu()
 
-            deleteAction = menu.addAction("Delete")
-            deleteAction.setEnabled(self.apiClient is not None)
+    #         deleteAction = menu.addAction("Delete")
+    #         deleteAction.setEnabled(self.apiClient is not None)
 
-            action = menu.exec_(self.form.workspaceListView.viewport().mapToGlobal(pos))
+    #         action = menu.exec_(
+    #             self.form.workspaceListView.viewport().mapToGlobal(pos)
+    #         )
 
-            if action == deleteAction:
-                result = QtGui.QMessageBox.question(
-                    self,
-                    "Delete Workspace",
-                    "Are you sure you want to delete this workspace?",
-                    QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-                )
-                if result == QtGui.QMessageBox.Yes:
-                    self.apiClient.deleteWorkspace(
-                        self.workspacesModel.data(index)["_id"]
-                    )
-                    self.workspacesModel.refreshModel()
-        else:
-            menu = QtGui.QMenu()
-            addAction = menu.addAction("Add workspace")
-            addAction.setEnabled(self.apiClient is not None)
+    #         if action == deleteAction:
+    #             result = QtGui.QMessageBox.question(
+    #                 self,
+    #                 "Delete Workspace",
+    #                 "Are you sure you want to delete this workspace?",
+    #                 QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
+    #             )
+    #             if result == QtGui.QMessageBox.Yes:
+    #                 self.apiClient.deleteWorkspace(
+    #                     self.workspacesModel.data(index)["_id"]
+    #                 )
+    #                 self.workspacesModel.refreshModel()
+    #     else:
+    #         menu = QtGui.QMenu()
+    #         addAction = menu.addAction("Add workspace")
+    #         addAction.setEnabled(self.apiClient is not None)
 
-            action = menu.exec_(self.form.workspaceListView.viewport().mapToGlobal(pos))
+    #         action = menu.exec_(
+    #             self.form.workspaceListView.viewport().mapToGlobal(pos)
+    #         )
 
-            if action == addAction:
-                self.newWorkspaceBtnClicked()
+    #         if action == addAction:
+    #             self.newWorkspaceBtnClicked()
 
     def showFileContextMenuFile(self, file_item, pos, index):
         menu = QtGui.QMenu()
@@ -1272,54 +1277,53 @@ class WorkspaceView(QtGui.QDockWidget):
         self.handle(tryCreateDir)
         self.switchView()
 
-    # TODO disable
-    def newWorkspaceBtnClicked(self):
-        if self.apiClient is None and self.access_token is None:
-            print("You need to login first")
-            self.loginBtnClicked()
-            return
-        if self.apiClient is None and self.access_token is not None:
-            self.apiClient = APIClient(
-                "", "", baseUrl, lensUrl, self.access_token, self.user
-            )
+    # def newWorkspaceBtnClicked(self):
+    #     if self.apiClient is None and self.access_token is None:
+    #         print("You need to login first")
+    #         self.loginBtnClicked()
+    #         return
+    #     if self.apiClient is None and self.access_token is not None:
+    #         self.apiClient = APIClient(
+    #             "", "", baseUrl, lensUrl, self.access_token, self.user
+    #         )
 
-        dialog = NewWorkspaceDialog()
-        # Show the dialog and wait for the user to close it
-        if dialog.exec_() == QtGui.QDialog.Accepted:
-            workspaceName = dialog.nameEdit.text()
-            workspaceDesc = dialog.descEdit.toPlainText()
+    #     dialog = NewWorkspaceDialog()
+    #     # Show the dialog and wait for the user to close it
+    #     if dialog.exec_() == QtGui.QDialog.Accepted:
+    #         workspaceName = dialog.nameEdit.text()
+    #         workspaceDesc = dialog.descEdit.toPlainText()
 
-            personal_organisation = None
-            for organization in self.user["organizations"]:
-                if organization.get("name") == "Personal":
-                    personal_organisation = organization.get("_id")
-                    break
+    #         personal_organisation = None
+    #         for organization in self.user["organizations"]:
+    #             if organization.get("name") == "Personal":
+    #                 personal_organisation = organization.get("_id")
+    #                 break
 
-            if personal_organisation is None:
-                return
+    #         if personal_organisation is None:
+    #             return
 
-            self.apiClient.createWorkspace(
-                workspaceName, workspaceDesc, personal_organisation
-            )
+    #         self.apiClient.createWorkspace(
+    #             workspaceName, workspaceDesc, personal_organisation
+    #         )
 
-            # workspaceType = "Ondsel"
-            # workspaceId = result["_id"]
-            # workspaceUrl = cachePath + workspaceId #workspace id.
-            # workspaceRootDir = result["rootDirectory"]
+    #         # workspaceType = "Ondsel"
+    #         # workspaceId = result["_id"]
+    #         # workspaceUrl = cachePath + workspaceId #workspace id.
+    #         # workspaceRootDir = result["rootDirectory"]
 
-            self.workspacesModel.refreshModel()
+    #         self.workspacesModel.refreshModel()
 
-            # # Determine workspace type and get corresponding values
-            # if dialog.localRadio.isChecked():
-            #     workspaceType = "Local"
-            #     workspaceUrl = dialog.localFolderLabel.text()
-            # elif dialog.ondselRadio.isChecked():
-            #     workspaceType = "Ondsel"
-            #     workspaceUrl = cachePath + dialog.nameEdit.text()
-            # else:
-            #     workspaceType = "External"
-            #     workspaceUrl = dialog.externalServerEdit.text()
-            # Update workspaceListWidget with new workspace
+    #         # # Determine workspace type and get corresponding values
+    #         # if dialog.localRadio.isChecked():
+    #         #     workspaceType = "Local"
+    #         #     workspaceUrl = dialog.localFolderLabel.text()
+    #         # elif dialog.ondselRadio.isChecked():
+    #         #     workspaceType = "Ondsel"
+    #         #     workspaceUrl = cachePath + dialog.nameEdit.text()
+    #         # else:
+    #         #     workspaceType = "External"
+    #         #     workspaceUrl = dialog.externalServerEdit.text()
+    #         # Update workspaceListWidget with new workspace
 
     def get_server_package_file(self):
         response = requests.get(remote_package_url)
@@ -1366,124 +1370,123 @@ class WorkspaceView(QtGui.QDockWidget):
             self.form.updateAvailable.show()
 
 
-# TODO disable
-class NewWorkspaceDialog(QtGui.QDialog):
-    def __init__(self, parent=None):
-        super(NewWorkspaceDialog, self).__init__(parent)
-        self.setWindowTitle("Add Workspace")
-        self.setModal(True)
+# class NewWorkspaceDialog(QtGui.QDialog):
+#     def __init__(self, parent=None):
+#         super(NewWorkspaceDialog, self).__init__(parent)
+#         self.setWindowTitle("Add Workspace")
+#         self.setModal(True)
 
-        layout = QtGui.QVBoxLayout()
+#         layout = QtGui.QVBoxLayout()
 
-        # Radio buttons for selecting workspace type
-        # self.localRadio = QtGui.QRadioButton("Local")
-        # self.ondselRadio = QtGui.QRadioButton("Ondsel Server")
-        # self.ondselRadio.setToolTip(
-        #     "Ondsel currently supports only one workspace "
-        #     "that is added automatically on login."
-        # )
-        # self.ondselRadio.setEnabled(False)
-        # self.externalRadio = QtGui.QRadioButton("External Server")
-        # self.externalRadio.setToolTip(
-        #     "Currently external servers support is not implemented."
-        # )
-        # self.externalRadio.setEnabled(False)
+#         # Radio buttons for selecting workspace type
+#         # self.localRadio = QtGui.QRadioButton("Local")
+#         # self.ondselRadio = QtGui.QRadioButton("Ondsel Server")
+#         # self.ondselRadio.setToolTip(
+#         #     "Ondsel currently supports only one workspace "
+#         #     "that is added automatically on login."
+#         # )
+#         # self.ondselRadio.setEnabled(False)
+#         # self.externalRadio = QtGui.QRadioButton("External Server")
+#         # self.externalRadio.setToolTip(
+#         #     "Currently external servers support is not implemented."
+#         # )
+#         # self.externalRadio.setEnabled(False)
 
-        # button_group = QtGui.QButtonGroup()
-        # button_group.addButton(self.localRadio)
-        # button_group.addButton(self.ondselRadio)
-        # button_group.addButton(self.externalRadio)
+#         # button_group = QtGui.QButtonGroup()
+#         # button_group.addButton(self.localRadio)
+#         # button_group.addButton(self.ondselRadio)
+#         # button_group.addButton(self.externalRadio)
 
-        # group_box = QtGui.QGroupBox("type")
-        # group_box_layout = QtGui.QHBoxLayout()
-        # group_box_layout.addWidget(self.localRadio)
-        # group_box_layout.addWidget(self.ondselRadio)
-        # group_box_layout.addWidget(self.externalRadio)
-        # group_box.setLayout(group_box_layout)
+#         # group_box = QtGui.QGroupBox("type")
+#         # group_box_layout = QtGui.QHBoxLayout()
+#         # group_box_layout.addWidget(self.localRadio)
+#         # group_box_layout.addWidget(self.ondselRadio)
+#         # group_box_layout.addWidget(self.externalRadio)
+#         # group_box.setLayout(group_box_layout)
 
-        # Workspace Name
-        self.nameLabel = QtGui.QLabel("Name")
-        self.nameEdit = QtGui.QLineEdit()
-        nameHlayout = QtGui.QHBoxLayout()
-        nameHlayout.addWidget(self.nameLabel)
-        nameHlayout.addWidget(self.nameEdit)
+#         # Workspace Name
+#         self.nameLabel = QtGui.QLabel("Name")
+#         self.nameEdit = QtGui.QLineEdit()
+#         nameHlayout = QtGui.QHBoxLayout()
+#         nameHlayout.addWidget(self.nameLabel)
+#         nameHlayout.addWidget(self.nameEdit)
 
-        # Workspace description
-        self.descLabel = QtGui.QLabel("Description")
-        self.descEdit = QtGui.QTextEdit()
+#         # Workspace description
+#         self.descLabel = QtGui.QLabel("Description")
+#         self.descEdit = QtGui.QTextEdit()
 
-        # # Widgets for local workspace type
-        # self.localFolderLabel = QtGui.QLineEdit("")
-        # self.localFolderEdit = QtGui.QPushButton("Select folder")
-        # self.localFolderEdit.clicked.connect(self.show_folder_picker)
-        # h_layout = QtGui.QHBoxLayout()
-        # h_layout.addWidget(self.localFolderLabel)
-        # h_layout.addWidget(self.localFolderEdit)
+#         # # Widgets for local workspace type
+#         # self.localFolderLabel = QtGui.QLineEdit("")
+#         # self.localFolderEdit = QtGui.QPushButton("Select folder")
+#         # self.localFolderEdit.clicked.connect(self.show_folder_picker)
+#         # h_layout = QtGui.QHBoxLayout()
+#         # h_layout.addWidget(self.localFolderLabel)
+#         # h_layout.addWidget(self.localFolderEdit)
 
-        # # Widgets for external server workspace type
-        # self.externalServerLabel = QtGui.QLabel("Server URL")
-        # self.externalServerEdit = QtGui.QLineEdit()
+#         # # Widgets for external server workspace type
+#         # self.externalServerLabel = QtGui.QLabel("Server URL")
+#         # self.externalServerEdit = QtGui.QLineEdit()
 
-        # Add widgets to layout
-        # layout.addWidget(group_box)
-        layout.addLayout(nameHlayout)
-        layout.addWidget(self.descLabel)
-        layout.addWidget(self.descEdit)
-        # layout.addLayout(h_layout)
-        # layout.addWidget(self.externalServerLabel)
-        # layout.addWidget(self.externalServerEdit)
+#         # Add widgets to layout
+#         # layout.addWidget(group_box)
+#         layout.addLayout(nameHlayout)
+#         layout.addWidget(self.descLabel)
+#         layout.addWidget(self.descEdit)
+#         # layout.addLayout(h_layout)
+#         # layout.addWidget(self.externalServerLabel)
+#         # layout.addWidget(self.externalServerEdit)
 
-        # Connect radio buttons to updateDialog function
-        # self.localRadio.toggled.connect(self.updateDialog)
-        # self.ondselRadio.toggled.connect(self.updateDialog)
-        # self.externalRadio.toggled.connect(self.updateDialog)
-        # self.localRadio.setChecked(True)
+#         # Connect radio buttons to updateDialog function
+#         # self.localRadio.toggled.connect(self.updateDialog)
+#         # self.ondselRadio.toggled.connect(self.updateDialog)
+#         # self.externalRadio.toggled.connect(self.updateDialog)
+#         # self.localRadio.setChecked(True)
 
-        # Add OK and Cancel buttons
-        buttonBox = QtGui.QDialogButtonBox(
-            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
-        )
-        buttonBox.accepted.connect(self.accept)
-        buttonBox.rejected.connect(self.reject)
+#         # Add OK and Cancel buttons
+#         buttonBox = QtGui.QDialogButtonBox(
+#             QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
+#         )
+#         buttonBox.accepted.connect(self.accept)
+#         buttonBox.rejected.connect(self.reject)
 
-        # Add layout and buttons to dialog
-        self.setLayout(layout)
-        layout.addWidget(buttonBox)
+#         # Add layout and buttons to dialog
+#         self.setLayout(layout)
+#         layout.addWidget(buttonBox)
 
-    # Function to update the dialog when the workspace type is changed
-    def updateDialog(self):
-        pass
-        # if self.ondselRadio.isChecked():
-        #     self.nameLabel.setText("ondsel.com/")
-        # else:
-        #     self.nameLabel.setText("Name")
-        # self.localFolderLabel.setVisible(self.localRadio.isChecked())
-        # self.localFolderEdit.setVisible(self.localRadio.isChecked())
+#     # Function to update the dialog when the workspace type is changed
+#     def updateDialog(self):
+#         pass
+#         # if self.ondselRadio.isChecked():
+#         #     self.nameLabel.setText("ondsel.com/")
+#         # else:
+#         #     self.nameLabel.setText("Name")
+#         # self.localFolderLabel.setVisible(self.localRadio.isChecked())
+#         # self.localFolderEdit.setVisible(self.localRadio.isChecked())
 
-        # self.externalServerLabel.setVisible(self.externalRadio.isChecked())
-        # self.externalServerEdit.setVisible(self.externalRadio.isChecked())
+#         # self.externalServerLabel.setVisible(self.externalRadio.isChecked())
+#         # self.externalServerEdit.setVisible(self.externalRadio.isChecked())
 
-    # def show_folder_picker(self):
-    #     options = QtGui.QFileDialog.Options()
-    #     options |= QtGui.QFileDialog.ShowDirsOnly
-    #     folder_url = QtGui.QFileDialog.getExistingDirectory(
-    #         self, "Select Folder", options=options
-    #     )
-    #     if folder_url:
-    #         self.localFolderLabel.setText(folder_url)
+#     # def show_folder_picker(self):
+#     #     options = QtGui.QFileDialog.Options()
+#     #     options |= QtGui.QFileDialog.ShowDirsOnly
+#     #     folder_url = QtGui.QFileDialog.getExistingDirectory(
+#     #         self, "Select Folder", options=options
+#     #     )
+#     #     if folder_url:
+#     #         self.localFolderLabel.setText(folder_url)
 
-    # def okClicked(self):
-    #    pass
-    # if self.localRadio.isChecked():
-    #    if os.path.isdir(self.localFolderLabel.text()):
-    #        self.accept()
-    #    else:
-    #        result = QtGui.QMessageBox.question(
-    #            self,
-    #            "Wrong URL",
-    #            "The URL you entered is not correct.",
-    #            QtGui.QMessageBox.Ok,
-    #        )
+#     # def okClicked(self):
+#     #    pass
+#     # if self.localRadio.isChecked():
+#     #    if os.path.isdir(self.localFolderLabel.text()):
+#     #        self.accept()
+#     #    else:
+#     #        result = QtGui.QMessageBox.question(
+#     #            self,
+#     #            "Wrong URL",
+#     #            "The URL you entered is not correct.",
+#     #            QtGui.QMessageBox.Ok,
+#     #        )
 
 
 class SharingLinkEditDialog(QtGui.QDialog):

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -319,7 +319,7 @@ class WorkspaceListDelegate(QStyledItemDelegate):
     #         # Check if the click was within the button rect
     #         if button_rect.contains(event.pos()):
     #             # Handle button click here
-    #             print("Button clicked for item:", index.row())
+    #             logger.debug("Button clicked for item:", index.row())
     #             return True  # Event was handled
     #     return super(WorkspaceListDelegate, self).editorEvent(event, model,
     #                                                           option, index)
@@ -629,7 +629,7 @@ class WorkspaceView(QtGui.QDockWidget):
 
         # Create a workspace model and set it to the list
         # if self.apiClient is None and self.access_token is None:
-        #     print("You need to login first")
+        #     logger.debug("You need to login first")
         #     self.loginBtnClicked()
         #     self.enterWorkspace(index)
         #     return
@@ -1587,7 +1587,7 @@ class WorkspaceView(QtGui.QDockWidget):
 
     # def newWorkspaceBtnClicked(self):
     #     if self.apiClient is None and self.access_token is None:
-    #         print("You need to login first")
+    #         logger.debug("You need to login first")
     #         self.loginBtnClicked()
     #         return
     #     if self.apiClient is None and self.access_token is not None:

--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -378,7 +378,7 @@ class WorkspaceView(QtGui.QDockWidget):
             # self.access_token = self.generate_expired_token()
 
             if self.isTokenExpired(self.access_token):
-                user = None
+                self.user = None
                 self.logout()
             else:
                 self.user = loginData["user"]
@@ -392,7 +392,7 @@ class WorkspaceView(QtGui.QDockWidget):
                 # Set a timer to logout when token expires.
                 self.setTokenExpirationTimer(self.access_token)
         else:
-            user = None
+            self.user = None
             self.setUIForLogin(False)
         self.switchView()
 
@@ -491,7 +491,7 @@ class WorkspaceView(QtGui.QDockWidget):
             "Your authentication token has expired, you have been logged out.",
         )
 
-        user = None
+        self.user = None
         self.logout()
 
     def getTokenExpirationTime(self, token):
@@ -715,6 +715,8 @@ class WorkspaceView(QtGui.QDockWidget):
 
     def fileListClickedLoggedIn(self, file_item):
         if not file_item.is_folder and "modelId" in file_item.serverFileDict:
+            # currentModelId is used for the server model and is necessary to
+            # open models online
             self.currentModelId = file_item.serverFileDict["modelId"]
 
         if file_item.is_folder:
@@ -723,11 +725,11 @@ class WorkspaceView(QtGui.QDockWidget):
             self.form.thumbnail_label.show()
             path = self.currentWorkspaceModel.getFullPath()
             pixmap = Utils.extract_thumbnail(f"{path}/{self.currentFileName}")
-            if pixmap == None:
+            if pixmap is None:
                 pixmap = self.getServerThumbnail(
                     self.currentFileName, path, self.currentModelId
                 )
-                if pixmap == None:
+                if pixmap is None:
                     pixmap = QPixmap(f"{modPath}/Resources/thumbTest.png")
             self.form.thumbnail_label.setFixedSize(pixmap.width(), pixmap.height())
             self.form.thumbnail_label.setPixmap(pixmap)
@@ -847,7 +849,9 @@ class WorkspaceView(QtGui.QDockWidget):
             if result == QtGui.QMessageBox.Yes:
                 self.currentWorkspaceModel.deleteFile(index)
         if action == openOnlineAction:
+            self.currentModelId = file_item.serverFileDict['modelId']
             self.openModelOnline()
+            self.currentModelId = None
         elif action == downloadAction:
             self.currentWorkspaceModel.downloadFile(index)
         elif action == uploadAction:

--- a/WorkspaceView.ui
+++ b/WorkspaceView.ui
@@ -169,9 +169,6 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="toolTip">
-             <string>You can revert to an older version of the file</string>
-            </property>
            </widget>
           </item>
           <item>

--- a/WorkspaceView.ui
+++ b/WorkspaceView.ui
@@ -187,6 +187,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="makeActiveBtn">
+              <property name="text">
+               <string>Make active</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_4">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/WorkspaceView.ui
+++ b/WorkspaceView.ui
@@ -104,10 +104,10 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Add files to your workspace</string>
+         <string>Add files or directories to your workspace</string>
         </property>
         <property name="text">
-         <string>Add files</string>
+         <string>Add</string>
         </property>
        </widget>
       </item>

--- a/changeLog.md
+++ b/changeLog.md
@@ -3,3 +3,7 @@ Add notification string for available updates.
 
 # 2023.10.31.01
 Cosmetic improvements.  Remove deprecated local WS.
+
+# 2024.01.15.01
+Large update allowing multiple workspaces per user from different
+organizations.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Ondsel Lens</name>
-  <description>Workspace Manager for Ondsel and Local Workspaces</description>
+  <description>Workspace manager for Ondsel Lens workspaces</description>
   <version>2023.12.13.01</version>
   <date>2023-12-13</date>
   <maintainer email="development@ondsel.com">Ondsel Development</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Ondsel Lens</name>
   <description>Workspace manager for Ondsel Lens workspaces</description>
-  <version>2023.12.13.01</version>
-  <date>2023-12-13</date>
+  <version>2024.01.15.01</version>
+  <date>2024-01-15</date>
   <maintainer email="development@ondsel.com">Ondsel Development</maintainer>
   <license file="LICENSE">MIT</license>
   <url type="repository" branch="master">https://github.com/ondsel-Development/ondsel-lens</url>

--- a/version.py
+++ b/version.py
@@ -1,6 +1,10 @@
 import re
 from datetime import datetime
 
+import Utils
+
+logger = Utils.getLogger(__name__)
+
 
 def increment_version(version):
     version_parts = version.split(".")
@@ -12,7 +16,10 @@ def increment_version(version):
                 sequence_number += 1
             else:
                 sequence_number = 1
-            new_version = f"{today.year:04d}.{today.month:02d}.{today.day:02d}.{sequence_number:02d}"
+            new_version = (
+                f"{today.year:04d}.{today.month:02d}.{today.day:02d}"
+                f".{sequence_number:02d}"
+            )
             return new_version, f"{today.year}-{today.month:02d}-{today.day:02d}"
         except ValueError:
             pass
@@ -49,7 +56,7 @@ if __name__ == "__main__":
 
     if new_version != current_version:
         update_version_in_file(package_xml_file, new_version, new_date)
-        print(f"Version updated from {current_version} to {new_version}")
-        print(f"Date updated to {new_date}")
+        logger.info(f"Version updated from {current_version} to {new_version}")
+        logger.info(f"Date updated to {new_date}")
     else:
-        print("Version remains unchanged. No update needed.")
+        logger.info("Version remains unchanged. No update needed.")


### PR DESCRIPTION
As discussed in issue #75, the addon supports multiple workspaces per user from potentially different organizations.  This pull requests provides a large update on the addon to align functionality with the Lens cloud service.

A summary of the new features:
- Support for multiple workspaces
- Workspaces can originate from different organizations
- The workspaces allow an offline workflow
- Directories are supported
- Workspaces can be used to collaborate within organizations
- The addon allows switching between versions and making versions active

Closes #75.