### PR TITLE
repository URL wrong case in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,8 +6,8 @@
   <date>2024-01-22</date>
   <maintainer email="development@ondsel.com">Ondsel Development</maintainer>
   <license file="LICENSE">MIT</license>
-  <url type="repository" branch="master">https://github.com/ondsel-Development/ondsel-lens</url>
-  <url type="readme">https://github.com/ondsel-Development/ondsel-lens/blob/master/README.md</url>
+  <url type="repository" branch="master">https://github.com/Ondsel-Development/Ondsel-Lens</url>
+  <url type="readme">https://github.com/Ondsel-Development/Ondsel-Lens/blob/master/README.md</url>
   <icon>Resources/icons/OndselWorkbench.svg</icon>
 
   <content>


### PR DESCRIPTION
To silence this warning in terminal:
```
Addon Developer Warning: Repository URL set in package.xml file for addon Ondsel Lens (https://github.com/ondsel-Development/ondsel-lens) does not match the URL it was fetched from (https://github.com/Ondsel-Development/Ondsel-Lens)
```
