### PR TITLE
Automatically add the version to the changelog

### DIFF
--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -1883,28 +1883,28 @@ class SharingLinkEditDialog(QtGui.QDialog):
 
     def getLinkProperties(self):
         self.linkProperties["description"] = self.dialog.linkName.text()
-        self.linkProperties[
-            "canViewModel"
-        ] = self.dialog.canViewModelCheckBox.isChecked()
-        self.linkProperties[
-            "canViewModelAttributes"
-        ] = self.dialog.canViewModelAttributesCheckBox.isChecked()
-        self.linkProperties[
-            "canUpdateModel"
-        ] = self.dialog.canUpdateModelAttributesCheckBox.isChecked()
+        self.linkProperties["canViewModel"] = (
+            self.dialog.canViewModelCheckBox.isChecked()
+        )
+        self.linkProperties["canViewModelAttributes"] = (
+            self.dialog.canViewModelAttributesCheckBox.isChecked()
+        )
+        self.linkProperties["canUpdateModel"] = (
+            self.dialog.canUpdateModelAttributesCheckBox.isChecked()
+        )
 
-        self.linkProperties[
-            "canExportFCStd"
-        ] = self.dialog.canExportFCStdCheckBox.isChecked()
-        self.linkProperties[
-            "canExportSTEP"
-        ] = self.dialog.canExportSTEPCheckBox.isChecked()
-        self.linkProperties[
-            "canExportSTL"
-        ] = self.dialog.canExportSTLCheckBox.isChecked()
-        self.linkProperties[
-            "canExportOBJ"
-        ] = self.dialog.canExportOBJCheckBox.isChecked()
+        self.linkProperties["canExportFCStd"] = (
+            self.dialog.canExportFCStdCheckBox.isChecked()
+        )
+        self.linkProperties["canExportSTEP"] = (
+            self.dialog.canExportSTEPCheckBox.isChecked()
+        )
+        self.linkProperties["canExportSTL"] = (
+            self.dialog.canExportSTLCheckBox.isChecked()
+        )
+        self.linkProperties["canExportOBJ"] = (
+            self.dialog.canExportOBJCheckBox.isChecked()
+        )
 
         return self.linkProperties
 

--- a/version.py
+++ b/version.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+import sys
 
 
 def increment_version(version):
@@ -39,8 +40,31 @@ def update_version_in_file(filename, new_version, new_date):
         file.write(updated_content)
 
 
+def update_version_changelog(filename, new_version):
+    with open(filename, "r") as file:
+        content = file.read()
+
+    updated_content = re.sub(r"<version>", f"# {new_version}", content)
+
+    with open(filename, "w") as file:
+        file.write(updated_content)
+
+    if content == updated_content:
+        print(
+            """
+Please add a Changelog line such as:
+<version>
+This version introduces...
+        """
+        )
+        sys.exit(1)
+    else:
+        print(f"Changelog updated to version {new_version}")
+
+
 if __name__ == "__main__":
     package_xml_file = "./package.xml"
+    changelog_file = "./changeLog.md"
 
     with open(package_xml_file, "r") as file:
         package_xml_content = file.read()
@@ -54,5 +78,6 @@ if __name__ == "__main__":
         update_version_in_file(package_xml_file, new_version, new_date)
         print(f"Version updated from {current_version} to {new_version}")
         print(f"Date updated to {new_date}")
+        update_version_changelog(changelog_file, new_version)
     else:
         print("Version remains unchanged. No update needed.")


### PR DESCRIPTION
This PR introduces the following syntax to be used in the changelog:

```
<version>
Introducing feature...
```

The string ```<version>``` will be replaced by the version just as in `package.xml`.

If the line is not present, `version.py` will fail allowing the maintainer to add a line in the changelog. It prevents maintainers to forget adding a changelog entry.