### PR TITLE
Fix timer signed integer bug

### DIFF
--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -56,6 +56,7 @@ logger = Utils.getLogger(__name__)
 MAX_LENGTH_BASE_FILENAME = 30
 MAX_LENGTH_WORKSPACE_NAME = 33
 ELLIPSES = "..."
+MAX_INT32 = (1 << 31) - 1
 
 mw = Gui.getMainWindow()
 p = FreeCAD.ParamGet("User parameter:BaseApp/Ondsel")
@@ -545,12 +546,12 @@ class WorkspaceView(QtGui.QDockWidget):
 
             time_difference = expiration_time - current_time
             interval_milliseconds = max(0, time_difference.total_seconds() * 1000)
-
-            # Create a QTimer that triggers only once when the token is expired
-            self.token_timer = QtCore.QTimer()
-            self.token_timer.setSingleShot(True)
-            self.token_timer.timeout.connect(self.token_expired_handler)
-            self.token_timer.start(interval_milliseconds)
+            if interval_milliseconds < MAX_INT32:
+                # Create a QTimer that triggers only once when the token is expired
+                self.token_timer = QtCore.QTimer()
+                self.token_timer.setSingleShot(True)
+                self.token_timer.timeout.connect(self.token_expired_handler)
+                self.token_timer.start(interval_milliseconds)
         except ExpiredSignatureError as e:
             # unexpected
             self.logout()


### PR DESCRIPTION
Closes #84.

The expiration time of the token is about a month currently, making it too large to fit into an 4-byte signed int. This solution doesn't set the timer if the expiration time is so far away. It will probably not affect any users unless they leave FreeCAD open for 25 days and are logged into the addon for so long. And if it affects them, they simply get logged out but not with a message.