### PR TITLE
Fix a bug with importing config

### DIFF
--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -84,7 +84,7 @@ try:
 
     baseUrl = config.base_url
     lensUrl = config.lens_url
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 

--- a/changeLog.md
+++ b/changeLog.md
@@ -10,3 +10,6 @@ organizations.
 
 # 2024.01.22.01
 Minor issues have been fixed.
+
+<version>
+Solve minor bugs related to a changing environment.


### PR DESCRIPTION
Fixes #87.

When a system happens to have a `config` module, we don't get an `ImportError` but an `AttributeError`.