### PR TITLE
Improve issues with resizing the main window

### DIFF
--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -48,6 +48,7 @@ from PySide.QtGui import (
     QAction,
     QActionGroup,
     QMenu,
+    QSizePolicy,
     QPixmap,
 )
 
@@ -671,15 +672,22 @@ class WorkspaceView(QtGui.QDockWidget):
 
     def switchView(self):
         isFileView = self.currentWorkspace is not None
-        self.form.WorkspaceDetails.setVisible(isFileView)
-        self.form.fileList.setVisible(isFileView)
 
-        if self.user is None and self.workspacesModel.rowCount() == 0:
-            self.form.txtExplain.setVisible(True)
+        if isFileView:
             self.form.workspaceListView.setVisible(False)
+            self.form.WorkspaceDetails.setVisible(True)
+            self.form.fileList.setVisible(True)
+            self.form.fileList.setSizePolicy(
+                QSizePolicy.Preferred, QSizePolicy.Expanding
+            )
         else:
-            self.form.txtExplain.setVisible(False)
-            self.form.workspaceListView.setVisible(not isFileView)
+            self.form.WorkspaceDetails.setVisible(False)
+            self.form.fileList.setVisible(False)
+            if self.user is None and self.workspacesModel.rowCount() == 0:
+                self.form.txtExplain.setVisible(True)
+            else:
+                self.form.txtExplain.setVisible(False)
+                self.form.workspaceListView.setVisible(True)
 
     def backClicked(self):
         if self.currentWorkspace is None:
@@ -910,7 +918,6 @@ class WorkspaceView(QtGui.QDockWidget):
 
     def updateThumbnail(self, fileItem):
         fileName = fileItem.name
-        self.form.thumbnail_label.show()
         path = self.currentWorkspaceModel.getFullPath()
         pixmap = Utils.extract_thumbnail(f"{path}/{fileName}")
         if pixmap is None:
@@ -929,14 +936,18 @@ class WorkspaceView(QtGui.QDockWidget):
         #     # currentModelId is used for the server model and is necessary to
         #     # open models online
         #     self.currentModelId = file_item.serverFileDict["modelId"]
-        self.form.thumbnail_label.show()
         self.updateThumbnail(file_item)
         self.form.fileNameLabel.setText(renderFileName(fileName))
-        self.form.fileNameLabel.show()
 
         version_model = None
         self.links_model = None
 
+        self.form.fileList.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
+        self.form.fileDetails.setSizePolicy(
+            QSizePolicy.Preferred, QSizePolicy.Expanding
+        )
+        self.form.thumbnail_label.show()
+        self.form.fileNameLabel.show()
         self.form.fileDetails.setVisible(True)
 
         # It seems an idea to have the values below as default to then set them when
@@ -975,6 +986,7 @@ class WorkspaceView(QtGui.QDockWidget):
         self.form.makeActiveBtn.setVisible(False)
         self.form.linkDetails.setVisible(False)
         self.form.fileDetails.setVisible(False)
+        self.form.fileList.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
 
     def fileListClickedLoggedOut(self, fileName):
         path = self.currentWorkspaceModel.getFullPath()

--- a/WorkspaceView.ui
+++ b/WorkspaceView.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>849</width>
-    <height>721</height>
+    <height>595</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,7 +26,7 @@
       <item>
        <widget class="QToolButton" name="userBtn">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -115,10 +115,44 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="txtExplain"/>
+    <widget class="QTextEdit" name="txtExplain">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QListView" name="workspaceListView">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string>List of your workspaces.</string>
      </property>
@@ -127,7 +161,7 @@
    <item>
     <widget class="QListView" name="fileList">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -142,19 +176,25 @@
      <layout class="QVBoxLayout">
       <item>
        <layout class="QHBoxLayout">
-        <item>
+        <item alignment="Qt::AlignTop">
          <widget class="QLabel" name="thumbnail_label">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>128</width>
+            <height>128</height>
+           </size>
           </property>
          </widget>
         </item>
         <item>
          <layout class="QVBoxLayout">
-          <item>
+          <item alignment="Qt::AlignTop">
            <widget class="QLabel" name="fileNameLabel">
             <property name="text">
              <string>part.FCStd</string>
@@ -265,7 +305,7 @@
          <item>
           <widget class="QListView" name="linksView">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>


### PR DESCRIPTION
On small screens the Ondsel Lens addon may change the main window.  This work improves on that but doesn't completely solve it if the window is extremely small.