### PR TITLE
Restrict the number of chars for share link name

### DIFF
--- a/SharingLinkEditDialog.ui
+++ b/SharingLinkEditDialog.ui
@@ -24,7 +24,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="linkName"/>
+      <widget class="QLineEdit" name="linkName">
+       <property name="maxLength">
+        <number>20</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="canViewModelCheckBox">


### PR DESCRIPTION
The restriction for the share link has been added to the .ui file, so the QLineEdit can simply not take more characters than necessary,