### PR TITLE
fix: wrong casing for set_frame_update function

### DIFF
--- a/WorkspaceView.py
+++ b/WorkspaceView.py
@@ -2277,7 +2277,7 @@ class WorkspaceView(QtGui.QDockWidget):
         )
 
         if local_version and remote_version and local_version != remote_version:
-            self.setFrameUpdate("Ondsel Lens", remote_version, self.openAddonManager)
+            self.set_frame_update("Ondsel Lens", remote_version, self.openAddonManager)
         else:
             self.check_for_update_ondsel_es()
 


### PR DESCRIPTION
I got this error while booting Ondsel
```
During initialization the error "'WorkspaceView' object has no attribute 'setFrameUpdate'" occurred in /home/jesse/.local/share/Ondsel/Mod/Ondsel-Lens/./InitGui.py
Please look into the log file for further information
```
It looks like the function was changed to snake case, but the invocation was still camel case.